### PR TITLE
Fix sphinx warnings

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ Mimesis
 **Mimesis** is a fast and easy to use Python library for generating dummy data for a variety of purposes.  This data can be particularly useful during software development and testing.  For example, it could be used to populate a testing database for a web application with user information such as email addresses, usernames, first names, last names, etc. There are over eighteen different `data providers <http://mimesis.readthedocs.io/en/latest/providers.html>`_ available, which can produce data related to food, people, computer hardware, transportation, addresses, and more. Mimesis does not require any modules that are not in the Python standard library.
 
 Advantages
--------------
+----------
 
 Mimesis offers a number of advantages over other similar libraries, such
 as Faker:
@@ -151,7 +151,7 @@ them explicitly:
 
 
 Custom Data Providers
-----------------
+---------------------
 
 You also can add custom provider to ``Generic()``, using
 ``add_provider()`` method:

--- a/docs/part_1.rst
+++ b/docs/part_1.rst
@@ -1,6 +1,6 @@
-===========
+==========================================
 Generating mock data using Mimesis: Part I
-===========
+==========================================
 
 The ability to generate mock but valid data comes in handy in app
 development, where you need to work with databases. Filling in the
@@ -20,7 +20,7 @@ dependencies. Currently the library supports over 33 languages and over 23 class
 providers, supplying various data.
 
 Generating data
---------
+---------------
 
 Initially, we planned on showing data generation using the example of a
 small web-application Flask, but we decided against it because not
@@ -90,7 +90,7 @@ and the model in question are available.
     >>> Patient()._bootstrap(count=40000, locale='en')
 
 Introduction
---------
+------------
 
 It is worth noting that we will be showing the basic capabilities of the
 library and we will be using a few most common class providers, since

--- a/docs/part_2.rst
+++ b/docs/part_2.rst
@@ -1,6 +1,6 @@
-===========
+===========================================
 Generating mock data using Mimesis: Part II
-===========
+===========================================
 
 We have already `published <http://mimesis.readthedocs.io/en/latest/part_1.html>`_ how to generate mock
 data with the help of a Python library  — `Mimesis <https://github.com/lk-geimfari/mimesis>`__.

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -1,6 +1,6 @@
-===========
+==============
 Data Providers
-===========
+==============
 
 There are list of data providers:
 

--- a/mimesis/providers/internet.py
+++ b/mimesis/providers/internet.py
@@ -184,8 +184,9 @@ class Internet(BaseProvider):
         """Return random top level domain.
 
         :param domain_type: Type of domain.
-        Supported TLDs: ccTLD, gTLD, GeoTLD, uTLD, sTLD
+          Supported TLDs: ccTLD, gTLD, GeoTLD, uTLD, sTLD
         :return: Top level domain.
+        
         """
         # TODO: This is really ugly solution. Fix it.
         supported = tuple(TLD.keys())

--- a/mimesis/providers/internet.py
+++ b/mimesis/providers/internet.py
@@ -186,7 +186,6 @@ class Internet(BaseProvider):
         :param domain_type: Type of domain.
           Supported TLDs: ccTLD, gTLD, GeoTLD, uTLD, sTLD
         :return: Top level domain.
-        
         """
         # TODO: This is really ugly solution. Fix it.
         supported = tuple(TLD.keys())

--- a/mimesis/providers/personal.py
+++ b/mimesis/providers/personal.py
@@ -69,7 +69,7 @@ class Personal(BaseProvider):
         """Get a random name.
 
         :param gender: if 'male' then will returned male name,
-        if 'female' then female name,  if None return random from ones.
+            if 'female' then female name,  if None return random from ones.
         :return: Name.
         :Example:
             John.
@@ -137,7 +137,7 @@ class Personal(BaseProvider):
         """Generate username by template.
 
         :param template: Template ('U_d', 'U.d', 'U-d', 'ld', 'l-d', 'Ud',
-        'l.d', 'l_d', 'default')
+            'l.d', 'l_d', 'default')
         :return: Username.
         :Example:
             Celloid1873


### PR DESCRIPTION
Different warnings were fixed for the sphinx documentations. They were
mostly underline oder overline too shorts as well as missing indedations
either in the documentation files or in the docstings

The only one missing is 'Duplicate explicit target name: "here".' in the
index.rst file. I was unchanged since here refences two different
documents.