### PR TITLE
#294 - switch address format for nl

### DIFF
--- a/mimesis/data/nl/address.json
+++ b/mimesis/data/nl/address.json
@@ -1,5 +1,5 @@
 {
-  "address_fmt": "{st_num} {st_name}",
+  "address_fmt": "{st_name} {st_num}",
   "city": [
 	"Aagtdorp",
 	"Aalsmeer",


### PR DESCRIPTION
Changed address format to {st_name} {st_num} for locale nl.