### PR TITLE
builtin specprovider for locale nl

### DIFF
--- a/mimesis/builtins/__init__.py
+++ b/mimesis/builtins/__init__.py
@@ -3,6 +3,7 @@ from .ja import JapanSpecProvider
 from .ru import RussiaSpecProvider
 from .pt_br import BrazilSpecProvider
 from .de import GermanySpecProvider
+from .nl import NLSpecProvider
 
 __all__ = [
     'USASpecProvider',

--- a/mimesis/builtins/__init__.py
+++ b/mimesis/builtins/__init__.py
@@ -3,7 +3,7 @@ from .ja import JapanSpecProvider
 from .ru import RussiaSpecProvider
 from .pt_br import BrazilSpecProvider
 from .de import GermanySpecProvider
-from .nl import NLSpecProvider
+from .nl import NetherlandsSpecProvider
 
 __all__ = [
     'USASpecProvider',
@@ -11,5 +11,5 @@ __all__ = [
     'RussiaSpecProvider',
     'BrazilSpecProvider',
     'GermanySpecProvider',
-    'NLSpecProvider',
+    'NetherlandsSpecProvider',
 ]

--- a/mimesis/builtins/__init__.py
+++ b/mimesis/builtins/__init__.py
@@ -10,4 +10,5 @@ __all__ = [
     'RussiaSpecProvider',
     'BrazilSpecProvider',
     'GermanySpecProvider',
+    'NLSpecProvider',
 ]

--- a/mimesis/builtins/nl.py
+++ b/mimesis/builtins/nl.py
@@ -5,7 +5,7 @@ class NetherlandsSpecProvider(BaseSpecProvider):
     """Provides data specific to nl locale"""
 
     class Meta:
-        name = 'nl_provider'
+        name = 'netherlands_provider'
 
     def bsn(self) -> str:
         """Generate a random, but valid burgerservicenummer (BSN).
@@ -17,7 +17,7 @@ class NetherlandsSpecProvider(BaseSpecProvider):
         """
 
         # a bsn is valid when its 9 digits pass the '11 test'
-        def _is_valid_bsn(number):
+        def _is_valid_bsn(number: str) -> str:
             total = 0
             multiplier = 9
 

--- a/mimesis/builtins/nl.py
+++ b/mimesis/builtins/nl.py
@@ -1,0 +1,35 @@
+from mimesis.builtins.base import BaseSpecProvider
+
+
+class NLSpecProvider(BaseSpecProvider):
+    """Provides data specific to nl locale"""
+
+    class Meta:
+        name = 'nl_provider'
+
+    def bsn(self) -> str:
+        """Generate a random, but valid burgerservicenummer (BSN).
+
+        :returns: random BSN
+
+        :Example:
+            255159705
+        """
+
+        # a bsn is valid when its 9 digits pass the '11 test'
+        def is_valid_bsn(number):
+            total = 0
+            multiplier = 9
+
+            for char in number:
+                multiplier = -multiplier if multiplier == 1 else multiplier
+                total += int(char) * multiplier
+                multiplier -= 1
+
+            return total % 11 == 0
+
+        sample = str(self.random.randint(100000000, 999999999))
+        while not is_valid_bsn(sample):
+            sample = str(self.random.randint(100000000, 999999999))
+
+        return sample

--- a/mimesis/builtins/nl.py
+++ b/mimesis/builtins/nl.py
@@ -1,7 +1,7 @@
 from mimesis.builtins.base import BaseSpecProvider
 
 
-class NLSpecProvider(BaseSpecProvider):
+class NetherlandsSpecProvider(BaseSpecProvider):
     """Provides data specific to nl locale"""
 
     class Meta:
@@ -17,7 +17,7 @@ class NLSpecProvider(BaseSpecProvider):
         """
 
         # a bsn is valid when its 9 digits pass the '11 test'
-        def is_valid_bsn(number):
+        def _is_valid_bsn(number):
             total = 0
             multiplier = 9
 
@@ -29,7 +29,7 @@ class NLSpecProvider(BaseSpecProvider):
             return total % 11 == 0
 
         sample = str(self.random.randint(100000000, 999999999))
-        while not is_valid_bsn(sample):
+        while not _is_valid_bsn(sample):
             sample = str(self.random.randint(100000000, 999999999))
 
         return sample

--- a/tests/test_builtins/nl/test_nl_spec.py
+++ b/tests/test_builtins/nl/test_nl_spec.py
@@ -14,13 +14,14 @@ def test_ssn(nl):
     assert len(result) == 9
     assert result.isdigit()
 
-    test11 = result[0:1] * 9 + \
-             result[1:2] * 8 + \
-             result[2:3] * 7 + \
-             result[3:4] * 6 + \
-             result[4:5] * 5 + \
-             result[5:6] * 4 + \
-             result[6:7] * 3 + \
-             result[7:8] * 2 + \
-             result[8:9] * -1
+    # elaborate way to validate
+    test11 = int(result[0:1]) * 9 + \
+        int(result[1:2]) * 8 + \
+        int(result[2:3]) * 7 + \
+        int(result[3:4]) * 6 + \
+        int(result[4:5]) * 5 + \
+        int(result[5:6]) * 4 + \
+        int(result[6:7]) * 3 + \
+        int(result[7:8]) * 2 + \
+        int(result[8:9]) * -1
     assert test11 % 11 == 0

--- a/tests/test_builtins/nl/test_nl_spec.py
+++ b/tests/test_builtins/nl/test_nl_spec.py
@@ -1,5 +1,6 @@
 import pytest
 
+from mimesis import Generic
 from mimesis.builtins import NetherlandsSpecProvider
 
 
@@ -25,3 +26,11 @@ def test_ssn(nl):
         int(result[7:8]) * 2 + \
         int(result[8:9]) * -1
     assert test11 % 11 == 0
+
+
+def test_nl_meta():
+    generic = Generic('nl')
+    generic.add_provider(NetherlandsSpecProvider)
+    result = generic.netherlands_provider.bsn()
+    assert result is not None
+    assert len(result) == 9

--- a/tests/test_builtins/nl/test_nl_spec.py
+++ b/tests/test_builtins/nl/test_nl_spec.py
@@ -1,11 +1,11 @@
 import pytest
 
-from mimesis.builtins import NLSpecProvider
+from mimesis.builtins import NetherlandsSpecProvider
 
 
 @pytest.fixture
 def nl():
-    return NLSpecProvider()
+    return NetherlandsSpecProvider()
 
 
 def test_ssn(nl):

--- a/tests/test_builtins/nl/test_nl_spec.py
+++ b/tests/test_builtins/nl/test_nl_spec.py
@@ -1,0 +1,26 @@
+import pytest
+
+from mimesis.builtins import NLSpecProvider
+
+
+@pytest.fixture
+def nl():
+    return NLSpecProvider()
+
+
+def test_ssn(nl):
+    result = nl.bsn()
+    assert result is not None
+    assert len(result) == 9
+    assert result.isdigit()
+
+    test11 = result[0:1] * 9 + \
+             result[1:2] * 8 + \
+             result[2:3] * 7 + \
+             result[3:4] * 6 + \
+             result[4:5] * 5 + \
+             result[5:6] * 4 + \
+             result[6:7] * 3 + \
+             result[7:8] * 2 + \
+             result[8:9] * -1
+    assert test11 % 11 == 0


### PR DESCRIPTION
Added the NLSpecProvider for the locale nl to generate a _burgerservicenummer_ or BSN. This is the Dutch equivalent of a social security number.