### PR TITLE
Added explicit definition of provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Version 1.0.6
+
+**Added**:
+- Explicit definition of data-provider for `schema.Field`
+
+---
+
 ## Version 1.0.5
 
 **Added**:

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ flake8-ignore =
   mimesis/__init__.py F403
   tests/*.py D100 D101 D102 D104 D103 D401
   setup.py ALL
+  .test.py ALL
 
 addopts =
     -p no:logging

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -45,20 +45,9 @@ def valid_schema(_):
                 'ethereum_address': _('ethereum_address'),
             },
         },
-        'meta': {
-            'currency': _('currency_iso_code'),
-            'shirt_size': _('european_size'),
-            'issn': _('issn'),
-            'spices': _('spices'),
-            'gaming_platform': _('gaming_platform'),
-            'resolution': _('resolution'),
-            'http_code': _('http_status_code'),
-            'digit': _('digit'),
-            'home_path': _('home'),
-            'rna': _('rna'),
-            'alphabet': _('alphabet'),
-            'truck': _('truck'),
-            'unit': _('unit'),
+        'defined_cls': {
+            'title': _('personal.title'),
+            'title2': _('text.title'),
         },
     }
 


### PR DESCRIPTION
Some data providers have methods with the same name (`Personal.title` and `Text.title`) and previous version of `schema.Field` always returns a result of the method `title()` of provider `Personal()`:
```python
>>> from mimesis.schema import Field
>>> _ = Field('en')
>>> _('title')
'Mr.'
```
Now we can explicitly define that the method belongs to data-provider ``cls``:

```python
>>> _('title', cls='text')
'She spent her earliest years reading classic literature.'
>>> _('title', cls='personal')
'Mrs.'
```

---

In addition, an explicit definition significantly increases the speed of work:

**The result on defined `cls`**:
```python
_ = Field('en')
description = (
    lambda: {
        'id': _('cryptographic.uuid'),
        'name': _('text.word'),
        'version': _('development.version', pre_release=True),
        'timestamp': _('datetime.timestamp', posix=False),
        'owner': {
            'email': _('personal.email', key=str.lower, domains=['@example.com']),
            'token': _('cryptographic.token'),
            'creator': _('personal.full_name', gender=Gender.FEMALE),
        },
        'title': _('text.title')
    }
)
schema = Schema(schema=description)
cProfile.run('schema.create(iterations=1000)')
```
```
         269711 function calls (269584 primitive calls) in 0.549 seconds

   Ordered by: standard name

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     1000    0.018    0.000    0.547    0.001 .test.py:10(<lambda>)
        # ... shortened result.
```

**The result on undefined `cls`:**
```python
_ = Field('en')
description2 = (
    lambda: {
        'id': _('uuid'),
        'name': _('word'),
        'version': _('version', pre_release=True),
        'timestamp': _('timestamp', posix=False),
        'owner': {
            'email': _('email', key=str.lower, domains=['@example.com']),
            'token': _('token'),
            'creator': _('full_name', gender=Gender.FEMALE),
        },
        'title': _('title')
    }
)
schema2 = Schema(schema=description2)
cProfile.run('schema2.create(iterations=1000)')
```
```
         1283777 function calls (1283650 primitive calls) in 4.868 seconds

   Ordered by: standard name

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     1000    0.031    0.000    4.865    0.005 .test.py:25(<lambda>)
        # ... shortened result.
```
----