### PR TITLE
Documentaion fix and a variable name update

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -328,7 +328,7 @@ Here’s how it works:
     >>> from mimesis.builtins import BrazilSpecProvider
 
     >>> generic = Generic('pt-br')
-    >>> generic.add_provider(BrazilProvider)
+    >>> generic.add_provider(BrazilSpecProvider)
     >>> generic.brazil_provider.cpf()
     '696.441.186-00'
 

--- a/mimesis/providers/person.py
+++ b/mimesis/providers/person.py
@@ -45,17 +45,17 @@ class Person(BaseDataProvider):
         self._store['age'] = a
         return a
 
-    def child_count(self, max_childs: int = 5) -> int:
-        """Get a count of child's.
+    def child_count(self, max_children: int = 5) -> int:
+        """Get a count of children.
 
-        :param max_childs: Maximum count of child's.
+        :param max_children: Maximum count of children.
         :return: Ints. Depend on previous generated age.
         """
         a = self._store['age']
         if a == 0:
             a = self.age()
 
-        cc = 0 if a < 18 else self.random.randint(0, max_childs)
+        cc = 0 if a < 18 else self.random.randint(0, max_children)
         return cc
 
     def work_experience(self, working_start_age: int = 22) -> int:

--- a/tests/test_providers/test_person.py
+++ b/tests/test_providers/test_person.py
@@ -42,7 +42,7 @@ class TestPerson(object):
         assert result == 0
 
     def test_child_count(self, _person):
-        result = _person.child_count(max_childs=10)
+        result = _person.child_count(max_children=10)
         assert result <= 10
 
     def test_work_experience(self, _person):


### PR DESCRIPTION
The correct name of the class is BrazilSpecProvider
Variable name 'children' proposed in place of childs