### PR TITLE
change Unsplash image url with more relevance results

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -64,6 +64,7 @@ Contributors
 -  Simon `(DefaltSimon)`_
 -  dy `(duckyou)`_
 -  Arvind Prasanna `(aprasanna)`_
+-  Pavel Kasyanov `(RaidoS)`_
 
 .. _(lk-geimfari): https://github.com/lk-geimfari
 .. _(sobolevn): https://github.com/sobolevn
@@ -103,3 +104,4 @@ Contributors
 .. _(axce1): https://github.com/axce1
 .. _(DefaltSimon): https://github.com/DefaltSimon
 .. _(aprasanna): https://github.com/aprasanna
+.. _(RaidoS): https://github.com/RaidoS

--- a/mimesis/providers/internet.py
+++ b/mimesis/providers/internet.py
@@ -146,7 +146,7 @@ class Internet(BaseDataProvider):
 
         return url.format(width=width, height=height)
 
-    def stock_image(self, width: Size = 1900, 
+    def stock_image(self, width: Size = 1900,
                     height: Size = 1080, category: str = '') -> str:
         """Generate random stock image hosted on Unsplash.
 

--- a/mimesis/providers/internet.py
+++ b/mimesis/providers/internet.py
@@ -146,8 +146,8 @@ class Internet(BaseDataProvider):
 
         return url.format(width=width, height=height)
 
-    def stock_image(self, category: str = '',
-                    width: Size = 1900, height: Size = 1080) -> str:
+    def stock_image(self, width: Size = 1900, 
+                    height: Size = 1080, category: str = '') -> str:
         """Generate random stock image hosted on Unsplash.
 
         :param category: Category of images.
@@ -157,8 +157,8 @@ class Internet(BaseDataProvider):
         :type height: str or int
         :return: An image (Link to image).
         """
-        url = 'https://source.unsplash.com/category/' \
-              '{category}/{width}x{height}'
+        url = 'https://source.unsplash.com/' \
+              '{width}x{height}/?{category}'
 
         if not category:
             categories = [
@@ -167,7 +167,7 @@ class Internet(BaseDataProvider):
             ]
             category = self.random.choice(categories)
 
-        return url.format(category=category, width=width, height=height)
+        return url.format(width=width, height=height, category=category)
 
     def image_by_keyword(self, keyword: str = '') -> str:
         """Generate image by keyword.

--- a/tests/test_providers/test_internet.py
+++ b/tests/test_providers/test_internet.py
@@ -52,9 +52,9 @@ class TestInternet(object):
     def test_stock_image(self, net):
         result = net.stock_image()
         assert result is not None
-        result_2 = net.stock_image(category='nature').split('/')[-2]
+        result_2 = net.stock_image(category='nature').split("/")[-1][1:]
         assert result_2 == 'nature'
-        result_3 = net.stock_image(width=1900, height=1080).split('/')[-1]
+        result_3 = net.stock_image(width=1900, height=1080).split('/')[-2]
         assert result_3 == '1900x1080'
 
     def test_image_by_keyword(self, net):

--- a/tests/test_providers/test_internet.py
+++ b/tests/test_providers/test_internet.py
@@ -52,7 +52,7 @@ class TestInternet(object):
     def test_stock_image(self, net):
         result = net.stock_image()
         assert result is not None
-        result_2 = net.stock_image(category='nature').split("/")[-1][1:]
+        result_2 = net.stock_image(category='nature').split('/')[-1][1:]
         assert result_2 == 'nature'
         result_3 = net.stock_image(width=1900, height=1080).split('/')[-2]
         assert result_3 == '1900x1080'


### PR DESCRIPTION
Previous url returns not relevance image.
before:
https://source.unsplash.com/category/sea/1900x1080
now:
https://source.unsplash.com/1900x1080/?sea

in addition, category (or search keyword) can be coma separated list, like so https://source.unsplash.com/1900x1080/?sea,sun

Unsplash reference https://source.unsplash.com/