### PR TITLE
Changes how internal random generator works

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -22,19 +22,26 @@
             ],
             "version": "==1.4"
         },
+        "atomicwrites": {
+            "hashes": [
+                "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585",
+                "sha256:a24da68318b08ac9c9c45029f4a10371ab5b20e4226738e150e6e7c571630ae6"
+            ],
+            "version": "==1.1.5"
+        },
         "attrs": {
             "hashes": [
-                "sha256:1c7960ccfd6a005cd9f7ba884e6316b5e430a3f1a6c37c5f87d8b43f83b54ec9",
-                "sha256:a17a9573a6f475c99b551c0e0a812707ddda1ec9653bed04c13841404ed6f450"
+                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
+                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
             ],
-            "version": "==17.4.0"
+            "version": "==18.1.0"
         },
         "certifi": {
             "hashes": [
-                "sha256:14131608ad2fd56836d33a71ee60fa1c82bc9d2c8d98b7bdbc631fe1b3cd1296",
-                "sha256:edbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d"
+                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
+                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
             ],
-            "version": "==2018.1.18"
+            "version": "==2018.4.16"
         },
         "chardet": {
             "hashes": [
@@ -126,11 +133,11 @@
         },
         "flake8-builtins": {
             "hashes": [
-                "sha256:35123ebd0885171f0c15fcb95c4374dbff1f71e6dc309d6b16abfa8dba18be4d",
-                "sha256:5d9687d470fec564689599aae12422b39c1bc6e6ed92291d2e8d7a1ebc9e983b"
+                "sha256:8d806360767947c0035feada4ddef3ede32f0a586ef457e62d811b8456ad9a51",
+                "sha256:cd7b1b7fec4905386a3643b59f9ca8e305768da14a49a7efb31fe9364f33cd04"
             ],
             "index": "pypi",
-            "version": "==1.2.1"
+            "version": "==1.4.1"
         },
         "flake8-commas": {
             "hashes": [
@@ -164,10 +171,10 @@
         },
         "idna": {
             "hashes": [
-                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
-                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4"
+                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
+                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
             ],
-            "version": "==2.6"
+            "version": "==2.7"
         },
         "isort": {
             "hashes": [
@@ -186,23 +193,25 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:0dd8f72eeab0d2c3bd489025bb2f6a1b8342f9b198f6fc37b52d15cfa4531fea",
-                "sha256:11a625025954c20145b37ff6309cd54e39ca94f72f6bb9576d1195db6fa2442e",
-                "sha256:c9ce7eccdcb901a2c75d326ea134e0886abfbea5f93e91cc95de9507c0816c44"
+                "sha256:2b6b9893337bfd9166bee6a62c2b0c9fe7735dcf85948b387ec8cba30e85d8e8",
+                "sha256:6703844a52d3588f951883005efcf555e49566a48afd4db4e965d69b883980d3",
+                "sha256:a18d870ef2ffca2b8463c0070ad17b5978056f403fb64e3f15fe62a52db21cc0"
             ],
-            "version": "==4.1.0"
+            "version": "==4.2.0"
         },
         "mypy": {
             "hashes": [
-                "sha256:3bd95a1369810f7693366911d85be9f0a0bd994f6cb7162b7a994e5ded90e3d9",
-                "sha256:7247f9948d7cdaae9408a4ee1662a01853c24e668117b4419acf025b05fbe3ce"
+                "sha256:1b899802a89b67bb68f30d788bba49b61b1f28779436f06b75c03495f9d6ea5c",
+                "sha256:f472645347430282d62d1f97d12ccb8741f19f1572b7cf30b58280e4e0818739"
             ],
             "index": "pypi",
-            "version": "==0.580"
+            "version": "==0.610"
         },
         "pluggy": {
             "hashes": [
-                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff"
+                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff",
+                "sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c",
+                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
             ],
             "version": "==0.6.0"
         },
@@ -251,18 +260,18 @@
         },
         "pyroma": {
             "hashes": [
-                "sha256:fd00280a737f99094aed0b9d6b52456f53ca28803a7c5fb05055a6a071ae9659"
+                "sha256:664faca7691a372360cd6ecf04d459c1b7c221013d8e965e0ae83f82a07b57a7"
             ],
             "index": "pypi",
-            "version": "==2.3"
+            "version": "==2.3.1"
         },
         "pytest": {
             "hashes": [
-                "sha256:6266f87ab64692112e5477eba395cfedda53b1933ccd29478e671e73b420c19c",
-                "sha256:fae491d1874f199537fd5872b5e1f0e74a009b979df9d53d1553fd03da1703e1"
+                "sha256:26838b2bc58620e01675485491504c3aa7ee0faf335c37fcd5f8731ca4319591",
+                "sha256:32c49a69566aa7c333188149ad48b58ac11a426d5352ea3d8f6ce843f88199cb"
             ],
             "index": "pypi",
-            "version": "==3.5.0"
+            "version": "==3.6.1"
         },
         "pytest-benchmark": {
             "hashes": [
@@ -288,35 +297,35 @@
         },
         "pytest-flake8": {
             "hashes": [
-                "sha256:3996de65a1219697596acac755090c70c47ec901edc438ea88ce1aa6098fb905",
-                "sha256:43598dfa211242525897866ff35fa553ebd88177383783079099057c7ad04331"
+                "sha256:e5cdc4f459c9436ac6c649e428a014bb5988605858549397374ec29a776cae68",
+                "sha256:ec248d4a215d6c7cd9d3ca48f365ece0e3892b46d626c22a95ccc80188ff35ed"
             ],
             "index": "pypi",
-            "version": "==1.0.0"
+            "version": "==1.0.1"
         },
         "pytest-isort": {
             "hashes": [
-                "sha256:e92798127e21d22513c62070989f0fb3b712650e48a4db13e5b8e8034d367cfe",
-                "sha256:fc315e3ceac576f2b7000c4716a55063c45ed60c169ba2ede5a6b4aef97ce13e"
+                "sha256:ce36b62ca1108e16a8b8fc0d5a82302ba0796a3c352b093e13ccbb18e772edc6",
+                "sha256:d4d195ecfe33d81e258d251b2679b32216bad84131fb41984da22d9d0328a6fe"
             ],
             "index": "pypi",
-            "version": "==0.1.0"
+            "version": "==0.2.0"
         },
         "pytest-mock": {
             "hashes": [
-                "sha256:2dd545496af6a0559432b11de79f1fd4fa4a541ae2e01892d5ba6041f85f0994",
-                "sha256:2f980ff7b1e5c6945138b3572dcfdde18b5410bf12d3af751da820ab7f21f132"
+                "sha256:53801e621223d34724926a5c98bd90e8e417ce35264365d39d6c896388dcc928",
+                "sha256:d89a8209d722b8307b5e351496830d5cc5e192336003a485443ae9adeb7dd4c0"
             ],
             "index": "pypi",
-            "version": "==1.8.0"
+            "version": "==1.10.0"
         },
         "requests": {
             "hashes": [
-                "sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b",
-                "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
+                "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
+                "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
             ],
             "index": "pypi",
-            "version": "==2.18.4"
+            "version": "==2.19.1"
         },
         "six": {
             "hashes": [
@@ -357,10 +366,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b",
-                "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
+                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
+                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "version": "==1.22"
+            "version": "==1.23"
         }
     }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
 
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  - "pip install --disable-pip-version-check --user --upgrade pip"
+  - "python -m pip install --disable-pip-version-check --user --upgrade pip"
 
   # Setting up enviroment
   - "pip install pipenv"

--- a/mimesis/helpers.py
+++ b/mimesis/helpers.py
@@ -10,13 +10,13 @@ get a random item of the enum object.
 """
 
 import os
-import random
+import random as random_module
 from typing import Any, List, Optional, Sequence
 
 __all__ = ['Random', 'get_random_item']
 
 
-class Random(random.Random):
+class Random(random_module.Random):
     """Custom class for the possibility of extending.
 
     The class is a subclass of the class ``Random()`` from the module ``random``
@@ -119,4 +119,9 @@ def get_random_item(enum: Any, rnd: Optional[Random] = None) -> Any:
     """
     if rnd and isinstance(rnd, Random):
         return rnd.choice(list(enum))
-    return random.choice(list(enum))
+    return random_module.choice(list(enum))
+
+
+# Compat
+# See: https://github.com/lk-geimfari/mimesis/issues/469
+random = Random()

--- a/mimesis/providers/base.py
+++ b/mimesis/providers/base.py
@@ -17,6 +17,7 @@ class BaseProvider(object):
         """Initialize attributes.
 
         :param seed: Seed for random.
+            When set to `None` the current system time is used.
         """
         self.seed = seed
         self.random = random
@@ -24,7 +25,7 @@ class BaseProvider(object):
         if seed is not None:
             self.reseed(seed)
 
-    def reseed(self, seed: Seed) -> None:
+    def reseed(self, seed: Optional[Seed]) -> None:
         """Reseed the internal random generator.
 
         In case we use the default seed, we need to create a per instance
@@ -32,6 +33,7 @@ class BaseProvider(object):
         will always return the same values.
 
         :param seed: Seed for random.
+            When set to `None` the current system time is used.
         """
         if self.random is random:
             self.random = Random()

--- a/mimesis/providers/base.py
+++ b/mimesis/providers/base.py
@@ -3,7 +3,7 @@
 from typing import Any, Optional
 
 from mimesis.exceptions import NonEnumerableError
-from mimesis.helpers import Random, get_random_item
+from mimesis.helpers import Random, get_random_item, random
 from mimesis.typing import Seed
 from mimesis.utils import setup_locale
 
@@ -19,10 +19,25 @@ class BaseProvider(object):
         :param seed: Seed for random.
         """
         self.seed = seed
-        self.random = Random()
+        self.random = random
 
         if seed is not None:
-            self.random.seed(self.seed)
+            self.reseed(seed)
+
+    def reseed(self, seed: Seed) -> None:
+        """Reseed the internal random generator.
+
+        In case we use the default seed, we need to create a per instance
+        random generator, in this case two providers with the same seed
+        will always return the same values.
+
+        :param seed: Seed for random.
+        """
+        if self.random is random:
+            self.random = Random()
+
+        self.seed = seed
+        self.random.seed(self.seed)
 
     def _validate_enum(self, item: Any, enum: Any) -> Any:
         """Validate enum parameter of method in subclasses of BaseProvider.

--- a/mimesis/providers/business.py
+++ b/mimesis/providers/business.py
@@ -42,7 +42,7 @@ class Business(BaseDataProvider):
             self._data['company']['type'].get('abbr' if abbr else 'title'),
         )
 
-    def copyright(self) -> str:  # noqa: A002
+    def copyright(self) -> str:  # noqa: A003
         """Generate a random copyright.
 
         :return: Copyright of company.

--- a/mimesis/providers/cryptographic.py
+++ b/mimesis/providers/cryptographic.py
@@ -34,7 +34,7 @@ class Cryptographic(BaseDataProvider):
         bits = self.random.getrandbits(128)
         return str(uuid.UUID(int=bits, version=version))
 
-    def hash(self, algorithm: Optional[Algorithm] = None) -> str:  # noqa: A002
+    def hash(self, algorithm: Optional[Algorithm] = None) -> str:  # noqa: A003
         """Generate random hash.
 
         :param algorithm: Enum object ``Algorithm``.
@@ -47,7 +47,7 @@ class Cryptographic(BaseDataProvider):
             fn = getattr(hashlib, key)
             return fn(self.uuid().encode()).hexdigest()
 
-    def bytes(self, entropy: int = 32) -> Bytes:  # noqa: A002
+    def bytes(self, entropy: int = 32) -> Bytes:  # noqa: A003
         """Generate byte string containing *entropy* bytes.
 
         The string has *entropy* random bytes, each byte

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,12 +1,13 @@
 import pytest
 
 from mimesis.enums import Gender
-from mimesis.helpers import Random, get_random_item
+from mimesis.helpers import get_random_item
+from mimesis.helpers import random as _random
 
 
 @pytest.fixture
 def random():
-    return Random()
+    return _random
 
 
 def test_randints(random):


### PR DESCRIPTION
What have I done?
1. I have made it easy to provide global seed for all providers at one place. For this purpose I am exposing `mimesis.helpers.random` instance
2. I have also changed how `seed` argument works. Now first call to the `reseed()` method creates an internal instance of `Random` to generate equal values for different instances of the same provider
3. I have also fixed `flake8-builtins` warnings 

Closes #470 
Closes #467
Related #469