### PR TITLE
Implemented timezone support, #485

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -28,4 +28,3 @@ colorama = { version="*", os_name="=='nt'"}
 "flake8-docstrings" = "*"
 pyroma = "*"
 pygments = "*"
-pytz = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -1,16 +1,11 @@
 [[source]]
-
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 name = "pypi"
 
-
 [packages]
 
-
-
 [dev-packages]
-
 codecov = "*"
 "flake8" = "*"
 "flake8-builtins" = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -28,3 +28,4 @@ colorama = { version="*", os_name="=='nt'"}
 "flake8-docstrings" = "*"
 pyroma = "*"
 pygments = "*"
+pytz = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,6 +1,7 @@
+{
     "_meta": {
         "hash": {
-            "sha256": "0a7196b0dda81c2f36b496afaef9e39fb3bb72473cd85689321c901ee6d88b16"
+            "sha256": "304ea8addd81a155425366708b56667b5c29abfca2e30a0b95dd6f923d9529a8"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -19,15 +20,16 @@
                 "sha256:37228cda29411948b422fae072f57e31d3396d2ee1c9783775980ee9c9990af6",
                 "sha256:58587dd4dc3daefad0487f6d9ae32b4542b185e1c36db6993290e7c41ca2b47c"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.0.*'",
+            "markers": "python_version != '3.0.*' and python_version != '3.2.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.1.*'",
             "version": "==1.5"
         },
         "atomicwrites": {
             "hashes": [
-                "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585",
-                "sha256:a24da68318b08ac9c9c45029f4a10371ab5b20e4226738e150e6e7c571630ae6"
+                "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
+                "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
             ],
-            "version": "==1.1.5"
+            "markers": "python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.3.*' and python_version >= '2.7'",
+            "version": "==1.2.1"
         },
         "attrs": {
             "hashes": [
@@ -38,10 +40,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
-                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
+                "sha256:376690d6f16d32f9d1fe8932551d80b23e9d393a8578c5633a2ed39a64861638",
+                "sha256:456048c7e371c089d0a77a5212fb37a2c2dce1e24146e3b7e0261736aaeaa22a"
             ],
-            "version": "==2018.4.16"
+            "version": "==2018.8.24"
         },
         "chardet": {
             "hashes": [
@@ -101,7 +103,7 @@
                 "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
                 "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80"
             ],
-            "markers": "python_version != '3.2.*' and python_version >= '2.6' and python_version < '4' and python_version != '3.1.*' and python_version != '3.0.*'",
+            "markers": "python_version != '3.0.*' and python_version != '3.2.*' and python_version < '4' and python_version >= '2.6' and python_version != '3.1.*'",
             "version": "==4.5.1"
         },
         "docutils": {
@@ -117,7 +119,7 @@
                 "sha256:a7a84d5fa07a089186a329528f127c9d73b9de57f1a1131b82bb5320ee651f6a",
                 "sha256:fc155a6b553c66c838d1a22dba1dc9f5f505c43285a878c6f74a79c024750b83"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.0.*'",
+            "markers": "python_version != '3.0.*' and python_version != '3.2.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.1.*'",
             "version": "==1.5.0"
         },
         "flake8": {
@@ -179,7 +181,7 @@
                 "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8",
                 "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.0.*'",
+            "markers": "python_version != '3.0.*' and python_version != '3.2.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.1.*'",
             "version": "==4.3.4"
         },
         "mccabe": {
@@ -210,16 +212,16 @@
                 "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
                 "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.0.*'",
+            "markers": "python_version != '3.0.*' and python_version != '3.2.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.1.*'",
             "version": "==0.7.1"
         },
         "py": {
             "hashes": [
-                "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
-                "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
+                "sha256:06a30435d058473046be836d3fc4f27167fd84c45b99704f2fb5509ef61f9af1",
+                "sha256:50402e9d1c9005d759426988a492e0edaadb7f4e68bcddfea586bc7432d009c6"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.0.*'",
-            "version": "==1.5.4"
+            "markers": "python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.3.*' and python_version >= '2.7'",
+            "version": "==1.6.0"
         },
         "py-cpuinfo": {
             "hashes": [
@@ -259,18 +261,19 @@
         },
         "pyroma": {
             "hashes": [
-                "sha256:664faca7691a372360cd6ecf04d459c1b7c221013d8e965e0ae83f82a07b57a7"
+                "sha256:3ed770a0ed1616ee2ffa576852e34fb1ea5b54c37ff78dd33cff67d0e4bb584b",
+                "sha256:94a11cb077976bff9bd37ac8b487902556f216c4ee90b74a2344367f73b6ee7f"
             ],
             "index": "pypi",
-            "version": "==2.3.1"
+            "version": "==2.4"
         },
         "pytest": {
             "hashes": [
-                "sha256:341ec10361b64a24accaec3c7ba5f7d5ee1ca4cebea30f76fad3dd12db9f0541",
-                "sha256:952c0389db115437f966c4c2079ae9d54714b9455190e56acebe14e8c38a7efa"
+                "sha256:2d7c49e931316cc7d1638a3e5f54f5d7b4e5225972b3c9838f3584788d27f349",
+                "sha256:ad0c7db7b5d4081631e0155f5c61b80ad76ce148551aaafe3a718d65a7508b18"
             ],
             "index": "pypi",
-            "version": "==3.6.4"
+            "version": "==3.7.4"
         },
         "pytest-benchmark": {
             "hashes": [
@@ -284,7 +287,7 @@
             "hashes": [
                 "sha256:be7468edd4d3d83f1e844959fd6e3fd28e77a481440a7118d430130ea31b07a9"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.0.*'",
+            "markers": "python_version != '3.0.*' and python_version != '3.2.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.1.*'",
             "version": "==1.0"
         },
         "pytest-cov": {
@@ -382,7 +385,7 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.3.*' and python_version >= '2.6' and python_version < '4' and python_version != '3.1.*' and python_version != '3.0.*'",
+            "markers": "python_version != '3.0.*' and python_version != '3.2.*' and python_version < '4' and python_version >= '2.6' and python_version != '3.3.*' and python_version != '3.1.*'",
             "version": "==1.23"
         }
     }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,4 +1,3 @@
-{
     "_meta": {
         "hash": {
             "sha256": "0a7196b0dda81c2f36b496afaef9e39fb3bb72473cd85689321c901ee6d88b16"
@@ -319,6 +318,14 @@
             ],
             "index": "pypi",
             "version": "==1.10.0"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:a061aa0a9e06881eb8b3b2b43f05b9439d6583c206d0a6c340ff72a7b6669053",
+                "sha256:ffb9ef1de172603304d9d2819af6f5ece76f2e85ec10692a524dd876e72bf277"
+            ],
+            "index": "pypi",
+            "version": "==2018.5"
         },
         "requests": {
             "hashes": [

--- a/mimesis/compat.py
+++ b/mimesis/compat.py
@@ -1,0 +1,6 @@
+"""Import additional dependancies only when needed."""
+
+try:
+    import pytz
+except ImportError:
+    pytz = None

--- a/mimesis/compat.py
+++ b/mimesis/compat.py
@@ -1,6 +1,6 @@
 """Import additional dependancies only when needed."""
 
 try:
-    import pytz
+    import pytz # type: ignore
 except ImportError:
-    pytz = None
+    pytz = None # type: ignore

--- a/mimesis/compat.py
+++ b/mimesis/compat.py
@@ -1,6 +1,6 @@
 """Import additional dependancies only when needed."""
 
 try:
-    import pytz # type: ignore
+    import pytz
 except ImportError:
-    pytz = None # type: ignore
+    pytz = None   # type: ignore

--- a/mimesis/providers/date.py
+++ b/mimesis/providers/date.py
@@ -2,12 +2,12 @@
 
 from calendar import monthrange, timegm
 from datetime import date, datetime, time
-import pytz
 
 from mimesis.data import GMT_OFFSETS, ROMAN_NUMS, TIMEZONES
 from mimesis.providers.base import BaseDataProvider
 from mimesis.typing import DateTime, Timestamp
 from mimesis.utils import pull
+from mimesis.compat import pytz
 
 __all__ = ['Datetime']
 
@@ -201,8 +201,11 @@ class Datetime(BaseDataProvider):
             return dt.strftime('%B, %d %Y')
 
         if timezone != '':
-            timezone = pytz.timezone(timezone)
-            dt = timezone.localize(dt)
+            if not pytz:
+                raise ImportError('Timezones are supported only with pytz')
+            else:
+                timezone = pytz.timezone(timezone)
+                dt = timezone.localize(dt)
 
         return dt
 

--- a/mimesis/providers/date.py
+++ b/mimesis/providers/date.py
@@ -200,7 +200,7 @@ class Datetime(BaseDataProvider):
         if humanized:
             return dt.strftime('%B, %d %Y')
 
-        if timezone != '' and not humanized:
+        if timezone != '':
             if not pytz:
                 raise ImportError('Timezones are supported only with pytz')
             else:

--- a/mimesis/providers/date.py
+++ b/mimesis/providers/date.py
@@ -2,6 +2,7 @@
 
 from calendar import monthrange, timegm
 from datetime import date, datetime, time
+import pytz
 
 from mimesis.data import GMT_OFFSETS, ROMAN_NUMS, TIMEZONES
 from mimesis.providers.base import BaseDataProvider
@@ -176,10 +177,11 @@ class Datetime(BaseDataProvider):
         """
         return self.random.choice(GMT_OFFSETS)
 
-    def datetime(self, humanized: bool = False, **kwargs) -> DateTime:
+    def datetime(self, humanized: bool = False, timezone: str = '', **kwargs) -> DateTime:
         """Generate random datetime.
 
         :param humanized: Readable representation.
+        :param timezone: Custom timezone.
         :param kwargs: Keyword arguments (start, end).
         :return: Datetime.
         :rtype: datetime.datetime
@@ -197,6 +199,10 @@ class Datetime(BaseDataProvider):
 
         if humanized:
             return dt.strftime('%B, %d %Y')
+
+        if timezone != '':
+            timezone = pytz.timezone(timezone)
+            dt = timezone.localize(dt)
 
         return dt
 

--- a/mimesis/providers/date.py
+++ b/mimesis/providers/date.py
@@ -200,7 +200,7 @@ class Datetime(BaseDataProvider):
         if humanized:
             return dt.strftime('%B, %d %Y')
 
-        if timezone != '':
+        if timezone != '' and not humanized:
             if not pytz:
                 raise ImportError('Timezones are supported only with pytz')
             else:

--- a/mimesis/providers/date.py
+++ b/mimesis/providers/date.py
@@ -3,11 +3,11 @@
 from calendar import monthrange, timegm
 from datetime import date, datetime, time
 
+from mimesis.compat import pytz
 from mimesis.data import GMT_OFFSETS, ROMAN_NUMS, TIMEZONES
 from mimesis.providers.base import BaseDataProvider
 from mimesis.typing import DateTime, Timestamp
 from mimesis.utils import pull
-from mimesis.compat import pytz
 
 __all__ = ['Datetime']
 
@@ -177,7 +177,8 @@ class Datetime(BaseDataProvider):
         """
         return self.random.choice(GMT_OFFSETS)
 
-    def datetime(self, humanized: bool = False, timezone: str = '', **kwargs) -> DateTime:
+    def datetime(self, humanized: bool = False,
+                 timezone: str = '', **kwargs) -> DateTime:
         """Generate random datetime.
 
         :param humanized: Readable representation.
@@ -205,9 +206,8 @@ class Datetime(BaseDataProvider):
         if timezone != '':
             if not pytz:
                 raise ImportError('Timezones are supported only with pytz')
-            else:
-                timezone = pytz.timezone(timezone)
-                dt = timezone.localize(dt)
+            tz = pytz.timezone(timezone)
+            dt = tz.localize(dt)
 
         return dt
 

--- a/mimesis/providers/date.py
+++ b/mimesis/providers/date.py
@@ -181,7 +181,9 @@ class Datetime(BaseDataProvider):
         """Generate random datetime.
 
         :param humanized: Readable representation.
-        :param timezone: Custom timezone.
+        :param timezone: Set custom timezone,
+        pytz (timezone library) installation required for use.
+
         :param kwargs: Keyword arguments (start, end).
         :return: Datetime.
         :rtype: datetime.datetime

--- a/mimesis/providers/date.py
+++ b/mimesis/providers/date.py
@@ -2,7 +2,6 @@
 
 from calendar import monthrange, timegm
 from datetime import date, datetime, time
-import pytz
 
 from mimesis.data import GMT_OFFSETS, ROMAN_NUMS, TIMEZONES
 from mimesis.providers.base import BaseDataProvider
@@ -165,7 +164,6 @@ class Datetime(BaseDataProvider):
         :Example:
             Europe/Paris
         """
-
         return self.random.choice(TIMEZONES)
 
     def gmt_offset(self) -> str:
@@ -178,11 +176,10 @@ class Datetime(BaseDataProvider):
         """
         return self.random.choice(GMT_OFFSETS)
 
-    def datetime(self, humanized: bool = False, timezone: str = '', **kwargs) -> DateTime:
+    def datetime(self, humanized: bool = False, **kwargs) -> DateTime:
         """Generate random datetime.
 
         :param humanized: Readable representation.
-        :param timezone: Custom timezone.
         :param kwargs: Keyword arguments (start, end).
         :return: Datetime.
         :rtype: datetime.datetime
@@ -190,9 +187,7 @@ class Datetime(BaseDataProvider):
         :Example:
             March, 24 2002
         """
-
         fmt = '%Y-%m-%d %H:%M:%S'
-
         dt_str = '{date} {time}'.format(
             date=self.date(fmt='%Y-%m-%d', **kwargs),
             time=self.time(),
@@ -202,10 +197,6 @@ class Datetime(BaseDataProvider):
 
         if humanized:
             return dt.strftime('%B, %d %Y')
-
-        if timezone != '':
-            timezone = pytz.timezone(timezone)
-            dt = timezone.localize(dt)
 
         return dt
 

--- a/mimesis/providers/date.py
+++ b/mimesis/providers/date.py
@@ -2,6 +2,7 @@
 
 from calendar import monthrange, timegm
 from datetime import date, datetime, time
+import pytz
 
 from mimesis.data import GMT_OFFSETS, ROMAN_NUMS, TIMEZONES
 from mimesis.providers.base import BaseDataProvider
@@ -164,6 +165,7 @@ class Datetime(BaseDataProvider):
         :Example:
             Europe/Paris
         """
+
         return self.random.choice(TIMEZONES)
 
     def gmt_offset(self) -> str:
@@ -176,10 +178,11 @@ class Datetime(BaseDataProvider):
         """
         return self.random.choice(GMT_OFFSETS)
 
-    def datetime(self, humanized: bool = False, **kwargs) -> DateTime:
+    def datetime(self, humanized: bool = False, timezone: str = '', **kwargs) -> DateTime:
         """Generate random datetime.
 
         :param humanized: Readable representation.
+        :param timezone: Custom timezone.
         :param kwargs: Keyword arguments (start, end).
         :return: Datetime.
         :rtype: datetime.datetime
@@ -187,7 +190,9 @@ class Datetime(BaseDataProvider):
         :Example:
             March, 24 2002
         """
+
         fmt = '%Y-%m-%d %H:%M:%S'
+
         dt_str = '{date} {time}'.format(
             date=self.date(fmt='%Y-%m-%d', **kwargs),
             time=self.time(),
@@ -197,6 +202,10 @@ class Datetime(BaseDataProvider):
 
         if humanized:
             return dt.strftime('%B, %d %Y')
+
+        if timezone != '':
+            timezone = pytz.timezone(timezone)
+            dt = timezone.localize(dt)
 
         return dt
 

--- a/tests/test_providers/test_datetime.py
+++ b/tests/test_providers/test_datetime.py
@@ -105,9 +105,8 @@ class TestDatetime(object):
         ],
     )
     def test_datetime(self, _datetime, start, end, humanized, timezone, _type):
-        dt = _datetime.datetime(start=start, end=end,
-                                humanized=humanized, timezone=timezone)
-
+        dt = _datetime.datetime(start=start, end=end, humanized=humanized, timezone=timezone)
+        
         assert dt is not None
         assert isinstance(dt, _type)
 

--- a/tests/test_providers/test_datetime.py
+++ b/tests/test_providers/test_datetime.py
@@ -98,13 +98,14 @@ class TestDatetime(object):
         assert isinstance(result, _type)
 
     @pytest.mark.parametrize(
-        'start, end, humanized, _type', [
-            (2018, 2018, False, datetime.datetime),
-            (2018, 2018, True, str),
+        'start, end, humanized, timezone, _type', [
+            (2018, 2018, False, "Europe/Paris", datetime.datetime),
+            (2018, 2018, True, "", str),
+            (2018, 2018, False, "", datetime.datetime),
         ],
     )
-    def test_datetime(self, _datetime, start, end, humanized, _type):
-        dt = _datetime.datetime(start=start, end=end, humanized=humanized)
+    def test_datetime(self, _datetime, start, end, humanized, timezone, _type):
+        dt = _datetime.datetime(start=start, end=end, humanized=humanized, timezone=timezone)
 
         assert dt is not None
         assert isinstance(dt, _type)
@@ -112,6 +113,13 @@ class TestDatetime(object):
         if _type is str:
             year = int(dt.split(' ')[2])
             assert year == 2018
+
+        if humanized == True:
+            pass
+        elif timezone != "":
+            assert dt.tzinfo != None
+        else:
+            assert dt.tzinfo == None
 
     def test_week_date(self, _datetime):
         result = _datetime.week_date(start=2017, end=2018)

--- a/tests/test_providers/test_datetime.py
+++ b/tests/test_providers/test_datetime.py
@@ -99,13 +99,14 @@ class TestDatetime(object):
 
     @pytest.mark.parametrize(
         'start, end, humanized, timezone, _type', [
-            (2018, 2018, False, "Europe/Paris", datetime.datetime),
-            (2018, 2018, True, "", str),
-            (2018, 2018, False, "", datetime.datetime),
+            (2018, 2018, False, 'Europe/Paris', datetime.datetime),
+            (2018, 2018, True, '', str),
+            (2018, 2018, False, '', datetime.datetime),
         ],
     )
     def test_datetime(self, _datetime, start, end, humanized, timezone, _type):
-        dt = _datetime.datetime(start=start, end=end, humanized=humanized, timezone=timezone)
+        dt = _datetime.datetime(start=start, end=end,
+                                humanized=humanized, timezone=timezone)
 
         assert dt is not None
         assert isinstance(dt, _type)
@@ -114,12 +115,12 @@ class TestDatetime(object):
             year = int(dt.split(' ')[2])
             assert year == 2018
 
-        if humanized == True:
+        if humanized:
             pass
-        elif timezone != "":
-            assert dt.tzinfo != None
+        elif timezone is not '':
+            assert dt.tzinfo is not None
         else:
-            assert dt.tzinfo == None
+            assert dt.tzinfo is None
 
     def test_week_date(self, _datetime):
         result = _datetime.week_date(start=2017, end=2018)

--- a/tests/test_providers/test_datetime.py
+++ b/tests/test_providers/test_datetime.py
@@ -105,8 +105,8 @@ class TestDatetime(object):
         ],
     )
     def test_datetime(self, _datetime, start, end, humanized, timezone, _type):
-        dt = _datetime.datetime(start=start, end=end, humanized=humanized, timezone=timezone)
-        
+        dt = _datetime.datetime(start=start, end=end,
+                                humanized=humanized, timezone=timezone)
         assert dt is not None
         assert isinstance(dt, _type)
 


### PR DESCRIPTION
Added feature from issue #485 to allow custom timezones with datetime.

Below is an example of usage:

```python
>>> d = Datetime()
>>> d.datetime(timezone="Europe/Paris")
datetime.datetime(2003, 12, 18, 4, 53, 48,  tzinfo=<DstTzInfo 'Europe/Paris' CEST+2:00:00 DST>)
```

This enhancement requires pytz. 