### PR TITLE
Fix pipenv with pip==18.1 bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ before_install: |
 
 install:
   - pip install pipenv
+  - pipenv run pip install pip==18.0
   - pipenv install --dev --ignore-pipfile
 
 script:


### PR DESCRIPTION
There is [bug](https://github.com/pypa/pipenv/issues/2924) with pipenv used with pip==18.1.
Because of that all Travis builds for python3.7 are failing.
I added temporary workaround.