### PR TITLE
Add to .gitignore Visual Studio Code trash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,6 @@ fabric.properties
 .test.py
 
 .pytest_cache/
+
+#vscode
+*.code-workspace


### PR DESCRIPTION
So with this PR `.gitignore` was extended with `.code-workspace`. 