### PR TITLE
Fix issue #609 and improve unit test for Person.username()

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -74,6 +74,7 @@ Contributors
 -  Sadie Bartholomew `(sadielbartholomew)`_
 -  Nazar Oleksiuk `(DevAerial)`_
 -  Ivan Ramos `(expandedmind)`_
+-  Jack Henry `(jackhenry)`_
 
 .. _(lk-geimfari): https://github.com/lk-geimfari
 .. _(sobolevn): https://github.com/sobolevn
@@ -124,3 +125,4 @@ Contributors
 .. _(DevAerial): https://github.com/DevAerial
 .. _(expandedmind): https://github.com/ExpandedMind
 .. _(lucasmarcel): https://github.com/lucasmarcel
+.. _(jackhenry): https://github.com/jackhenry

--- a/mimesis/providers/person.py
+++ b/mimesis/providers/person.py
@@ -180,7 +180,9 @@ class Person(BaseDataProvider):
         _name = self.random.choice(USERNAMES).capitalize()
 
         name = self.random.choice(USERNAMES)
-        date = self.random.randint(1800, 2070)
+        MIN_DATE = 1800
+        MAX_DATE = 2070
+        date = self.random.randint(MIN_DATE, MAX_DATE)
 
         templates = ('U-d', 'U.d', 'UU-d', 'UU.d', 'UU_d', 'U_d',
                      'Ud', 'l-d', 'l.d', 'l_d', 'ld', 'default')

--- a/tests/test_providers/patterns.py
+++ b/tests/test_providers/patterns.py
@@ -20,8 +20,6 @@ IP_V4_REGEX = r'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$'
 
 EMAIL_REGEX = r'(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)'
 
-USERNAME_REGEX = r'^[a-zA-Z0-9_.-]+$'
-
 CREDIT_CARD_REGEX = r'[\d]+((-|\s)?[\d]+)+'
 
 PROVIDER_STR_REGEX = r'^(Business|Clothing|Code|Development' \

--- a/tests/test_providers/test_person.py
+++ b/tests/test_providers/test_person.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import random
 import re
 
 import pytest
@@ -74,8 +75,30 @@ class TestPerson(object):
         ],
     )
     def test_username(self, _person, template):
+
+        templates = ('U-d', 'U.d', 'UU-d', 'UU.d', 'UU_d', 'U_d',
+                     'Ud', 'l-d', 'l.d', 'l_d', 'ld', 'default')
+
+        template_patterns = {
+            'U-d': r'^[A-Z][a-z]+-[0-9]+$',
+            'U.d': r'^[A-Z][a-z]+\.[0-9]+$',
+            'U_d': r'^[A-Z][a-z]+_[0-9]+$',
+            'UU-d': r'^[A-Z][a-z]+[A-Z][a-z]+-[0-9]+$',
+            'UU.d': r'^[A-Z][a-z]+[A-Z][a-z]+\.[0-9]+$',
+            'UU_d': r'^[A-Z][a-z]+[A-Z][a-z]+_[0-9]+$',
+            'Ud': r'^[A-Z][a-z]+[0-9]+$',
+            'l-d': r'^[a-z]+-[0-9]+$',
+            'l.d': r'^[a-z]+\.[0-9]+$',
+            'l_d': r'^[a-z]+_[0-9]+$',
+            'ld': r'^[a-z]+[0-9]+$',
+            'default': r'^[a-z]+\.[0-9]+',
+        }
+
+        if template is None:
+            template = random.choice(templates)
+
         result = _person.username(template=template)
-        assert re.match(patterns.USERNAME_REGEX, result)
+        assert re.match(template_patterns[template], result)
 
     def test_username_unsupported_template(self, _person):
         with pytest.raises(KeyError):


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

<!-- You can uncomment the section below if this is your very first PR to this repository. -->

- [x] I have read [contributing guidelines](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTING.rst)
- [x] I have added myself to the [CONTRIBUTORS.rst](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTORS.rst)

- [x] I'm sure that I did not unrelated changes in this pull request
- [x] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the [CHANGELOG.rst](https://github.com/lk-geimfari/mimesis/blob/master/CHANGELOG.rst)


## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
- Closes #609 

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
Couple of things:

**1**. Assigned the hard coded values to ```MIN_DATE``` and ```MAX_DATE```. I will be able to use these while I implement #608.

**2**. I noticed that the unit test for ```Person.email()``` was asserting the returned value with a generic regular expression. I created patterns for each template. The unit test will now assert that the returned value of ```Person.email()``` matches the pattern for the template that was passed as a parameter.
