### PR TITLE
pass seed to custom provider

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Version 3.1.0
 **Fixed**:
 
 - Fixed ``UnsupportedField`` on using field ``choice``, `#619 <https://github.com/lk-geimfari/mimesis/issues/619>`_
+- Pass seed to custom providers
 
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,11 +1,17 @@
+Version 3.2.0
+-------------
+
+**Fixed**:
+
+- Pass seed to custom providers
+
+
 Version 3.1.0
 -------------
 
 **Fixed**:
 
 - Fixed ``UnsupportedField`` on using field ``choice``, `#619 <https://github.com/lk-geimfari/mimesis/issues/619>`_
-- Pass seed to custom providers
-
 
 
 Version 3.0.0

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -76,6 +76,7 @@ Contributors
 -  Ivan Ramos `(expandedmind)`_
 -  Jack Henry `(jackhenry)`_
 -  Nikita Serba `(Nekit10)`_
+-  Julien Surloppe `(jsurloppe)`_
 
 .. _(lk-geimfari): https://github.com/lk-geimfari
 .. _(sobolevn): https://github.com/sobolevn
@@ -128,3 +129,4 @@ Contributors
 .. _(lucasmarcel): https://github.com/lucasmarcel
 .. _(jackhenry): https://github.com/jackhenry
 .. _(Nekit10): https://github.com/Nekit10
+.. _(jsurloppe): https://github.com/jsurloppe

--- a/mimesis/providers/generic.py
+++ b/mimesis/providers/generic.py
@@ -114,7 +114,7 @@ class Generic(BaseDataProvider):
                 name = getattr(meta, 'name')
             except AttributeError:
                 name = cls.__name__.lower()
-            setattr(self, name, cls())
+            setattr(self, name, cls(seed=self.seed))
         else:
             raise TypeError('The provider must be a class')
 


### PR DESCRIPTION
Seed is not passed to custom provider when add_provider is called, this PR fix this.

## Checklist

- [x] I have read [contributing guidelines](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTING.rst)
- [x] I'm sure that I did not unrelated changes in this pull request
- [ ] I have created at least one test case for the changes I have made

- [x] I have added myself to the [CONTRIBUTORS.rst](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTORS.rst)

- [x] I have added my changes to the [CHANGELOG.rst](https://github.com/lk-geimfari/mimesis/blob/master/CHANGELOG.rst)
