### PR TITLE
DenmarkSpecProvider added

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Version 3.2.0
 -------------
 
+**Added**:
+
+- Added built-in provider DenmarkSpecProvider
+
+
 **Fixed**:
 
 - Pass seed to custom providers

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,6 +17,13 @@ BrazilSpecProvider
    :members:
    :special-members: __init__
 
+DenmarkSpecProvider
+------------------
+
+.. autoclass:: mimesis.builtins.DenmarkSpecProvider
+   :members:
+   :special-members: __init__
+
 GermanySpecProvider
 -------------------
 

--- a/mimesis/builtins/__init__.py
+++ b/mimesis/builtins/__init__.py
@@ -9,6 +9,7 @@ from .de import GermanySpecProvider
 from .nl import NetherlandsSpecProvider
 from .uk import UkraineSpecProvider
 from .pl import PolandSpecProvider
+from .da import DenmarkSpecProvider
 
 __all__ = [
     'USASpecProvider',
@@ -18,4 +19,5 @@ __all__ = [
     'NetherlandsSpecProvider',
     'UkraineSpecProvider',
     'PolandSpecProvider',
+    'DenmarkSpecProvider',
 ]

--- a/mimesis/builtins/da.py
+++ b/mimesis/builtins/da.py
@@ -2,12 +2,13 @@
 
 """Specific data provider for Denmark (da)."""
 
+import random
+
 from mimesis.builtins.base import BaseSpecProvider
 from mimesis.typing import Seed
 
-import random
-
 __all__ = ['DenmarkSpecProvider']
+
 
 class DenmarkSpecProvider(BaseSpecProvider):
     """Class that provides special data for Denmark (da)."""
@@ -20,7 +21,7 @@ class DenmarkSpecProvider(BaseSpecProvider):
         """The name of the provider."""
 
         name = 'denmark_provider'
-    
+
     def cpr(self) -> str:
         """Generate a random CPR number (Central Person Registry).
 
@@ -29,5 +30,11 @@ class DenmarkSpecProvider(BaseSpecProvider):
         :Example:
             0105865167
         """
-        cpr_nr = f'{"{:02d}".format(random.randint(1,31))}{"{:02d}".format(random.randint(1,12))}{"{:02d}".format(random.randint(0, 99))}{"{:04d}".format(random.randint(0, 9999))}'
+        day = '{:02d}'.format(random.randint(1, 31))
+        month = '{:02d}'.format(random.randint(1, 12))
+        year = '{:02d}'.format(random.randint(0, 99))
+        serial_number = '{:04d}'.format(random.randint(0, 9999))
+
+        cpr_nr = f'{day}{month}{year}{serial_number}'
+
         return cpr_nr

--- a/mimesis/builtins/da.py
+++ b/mimesis/builtins/da.py
@@ -30,11 +30,11 @@ class DenmarkSpecProvider(BaseSpecProvider):
         :Example:
             0105865167
         """
-        day = '{:02d}'.format(random.randint(1, 31))
-        month = '{:02d}'.format(random.randint(1, 12))
-        year = '{:02d}'.format(random.randint(0, 99))
-        serial_number = '{:04d}'.format(random.randint(0, 9999))
+        day = '{:02d}'.format(self.random.randint(1, 31))
+        month = '{:02d}'.format(self.random.randint(1, 12))
+        year = '{:02d}'.format(self.random.randint(0, 99))
+        serial_number = '{:04d}'.format(self.random.randint(0, 9999))
 
-        cpr_nr = f'{day}{month}{year}{serial_number}'
+        cpr_nr = '{}{}{}{}'.format(day, month, year, serial_number)
 
         return cpr_nr

--- a/mimesis/builtins/da.py
+++ b/mimesis/builtins/da.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+"""Specific data provider for Denmark (da)."""
+
+from mimesis.builtins.base import BaseSpecProvider
+from mimesis.typing import Seed
+
+import random
+
+__all__ = ['DenmarkSpecProvider']
+
+class DenmarkSpecProvider(BaseSpecProvider):
+    """Class that provides special data for Denmark (da)."""
+
+    def __init__(self, seed: Seed = None):
+        """Initialize attributes."""
+        super().__init__(locale='da', seed=seed)
+
+    class Meta:
+        """The name of the provider."""
+
+        name = 'denmark_provider'
+    
+    def cpr(self) -> str:
+        """Generate a random CPR number (Central Person Registry).
+
+        :return: CPR number.
+
+        :Example:
+            0105865167
+        """
+        cpr_nr = f'{"{:02d}".format(random.randint(1,31))}{"{:02d}".format(random.randint(1,12))}{"{:02d}".format(random.randint(0, 99))}{"{:04d}".format(random.randint(0, 9999))}'
+        return cpr_nr

--- a/tests/test_builtins/da/test_denmark_spec.py
+++ b/tests/test_builtins/da/test_denmark_spec.py
@@ -1,0 +1,14 @@
+import pytest
+
+from mimesis.builtins import DenmarkSpecProvider
+
+
+@pytest.fixture
+def denmark():
+    return DenmarkSpecProvider()
+
+
+def test_cpr(denmark):
+    cpr_number = denmark.cpr()
+    assert cpr_number is not None
+    assert len(cpr_number) == 10


### PR DESCRIPTION
I've added a _DenmarkSpecProvider_ for the _da_ locale so users can generate a _CPR-number_. This is the danish version of a social security number.