### PR TITLE
Refactor Path data provider with pathlib

### DIFF
--- a/mimesis/data/int/path.py
+++ b/mimesis/data/int/path.py
@@ -4,28 +4,16 @@
 
 # https://docs.python.org/3.5/library/sys.html?highlight=sys#sys.platform
 PLATFORMS = {
-    'LINUX': {
-        'name': 'linux',
-        'path_separator': '/',
-        'root': '/',
+    'linux': {
         'home': '/home/',
     },
-    'MACOS': {
-        'name': 'darwin',
-        'path_separator': '/',
-        'root': '/',
+    'darwin': {
         'home': '/home/',
     },
-    'WINDOWS': {
-        'name': 'win32',
-        'path_separator': '\\',
-        'root': 'C:\\',
+    'win32': {
         'home': 'C:\\Users\\',
     },
-    'WINDOWS64': {
-        'name': 'win64',
-        'path_separator': '\\',
-        'root': 'C:\\',
+    'win64': {
         'home': 'C:\\Users\\',
     },
 }

--- a/mimesis/providers/path.py
+++ b/mimesis/providers/path.py
@@ -3,7 +3,7 @@
 """Provides data related to paths."""
 
 import sys
-from typing import Union
+from pathlib import PurePosixPath, PureWindowsPath
 
 from mimesis.data import (
     FOLDERS,
@@ -29,8 +29,11 @@ class Path(BaseProvider):
         """
         super().__init__(*args, **kwargs)
         self.platform = platform
+        self._pathlib_home = PureWindowsPath() if 'win' in platform \
+                             else PurePosixPath()
+        self._pathlib_home /= PLATFORMS[platform]['home']
 
-    def root(self) -> Union[str, None]:
+    def root(self) -> str:
         """Generate a root dir path.
 
         :return: Root dir.
@@ -38,25 +41,19 @@ class Path(BaseProvider):
         :Example:
             /
         """
-        for platform in PLATFORMS:
-            if self.platform == PLATFORMS[platform]['name']:
-                root = PLATFORMS[platform]['root']
-                return root
+        return str(self._pathlib_home.parent)
 
-    def home(self) -> Union[str, None]:
+    def home(self) -> str:
         """Generate a home path.
 
         :return: Home path.
 
         :Example:
-            /home/
+            /home
         """
-        for platform in PLATFORMS:
-            if self.platform == PLATFORMS[platform]['name']:
-                home = PLATFORMS[platform]['home']
-                return home
+        return str(self._pathlib_home)
 
-    def user(self) -> Union[str, None]:
+    def user(self) -> str:
         """Generate a random user.
 
         :return: Path to user.
@@ -65,11 +62,10 @@ class Path(BaseProvider):
             /home/oretha
         """
         user = self.random.choice(USERNAMES)
-        user = user.capitalize() if \
-            self.platform == 'win32' else user.lower()
-        return '{}{}'.format(self.home(), user)
+        user = user.capitalize() if 'win' in self.platform else user.lower()
+        return str(self._pathlib_home / user)
 
-    def users_folder(self) -> Union[str, None]:
+    def users_folder(self) -> str:
         """Generate a random path to user's folders.
 
         :return: Path.
@@ -77,38 +73,24 @@ class Path(BaseProvider):
         :Example:
             /home/taneka/Pictures
         """
-        folder = self.random.choice(FOLDERS)
         user = self.user()
-        for platform in PLATFORMS:
-            if self.platform == PLATFORMS[platform]['name']:
-                sep = PLATFORMS[platform]['path_separator']
-                return '{user}{sep}{folder}'.format(
-                    user=user,
-                    sep=sep,
-                    folder=folder,
-                )
+        folder = self.random.choice(FOLDERS)
+        return str(self._pathlib_home / user / folder)
 
-    def dev_dir(self) -> Union[str, None]:
+    def dev_dir(self) -> str:
         """Generate a random path to development directory.
 
         :return: Path.
 
         :Example:
-            /home/sherrell/Development/Python/mercenary
+            /home/sherrell/Development/Python
         """
+        user = self.user()
         folder = self.random.choice(['Development', 'Dev'])
         stack = self.random.choice(PROGRAMMING_LANGS)
-        for platform in PLATFORMS:
-            if self.platform == PLATFORMS[platform]['name']:
-                sep = PLATFORMS[platform]['path_separator']
-                return '{user}{sep}{folder}{sep}{stack}'.format(
-                    user=self.user(),
-                    sep=sep,
-                    folder=folder,
-                    stack=stack,
-                )
+        return str(self._pathlib_home / user / folder / stack)
 
-    def project_dir(self) -> Union[str, None]:
+    def project_dir(self) -> str:
         """Generate a random path to project directory.
 
         :return: Path to project.
@@ -116,14 +98,6 @@ class Path(BaseProvider):
         :Example:
             /home/sherika/Development/Falcon/mercenary
         """
-        project = self.random.choice(PROJECT_NAMES)
         dev_dir = self.dev_dir()
-        for platform in PLATFORMS:
-            if self.platform == PLATFORMS[platform]['name']:
-                sep = PLATFORMS[platform]['path_separator']
-
-                return '{dev_dir}{sep}{project}'.format(
-                    dev_dir=dev_dir,
-                    sep=sep,
-                    project=project,
-                )
+        project = self.random.choice(PROJECT_NAMES)
+        return str(self._pathlib_home / dev_dir / project)

--- a/tests/test_providers/test_path.py
+++ b/tests/test_providers/test_path.py
@@ -6,36 +6,25 @@ import pytest
 from mimesis import Path
 from mimesis.data import FOLDERS, PROGRAMMING_LANGS, PROJECT_NAMES
 
-from . import patterns
-
 
 class TestPath(object):
 
-    # def test_str(self, path):
-    #     assert re.match(patterns.STR_REGEX, str(path))
-
     def test_root(self, path):
         result = path.root()
-        assert 'C:\\', '/' == result
+        assert result == 'C:\\' or result == '/'
 
     def test_home(self, path):
         result = path.home()
-        assert 'С:\\Users\\', '/home/' == result
+        assert result == 'C:\\Users' or result == '/home'
 
     def test_user(self, path):
         user = path.user()
-        pattern_dictionary = {
-            'win32': '(C)(:)(\\\\)(Users)(\\\\).*[^(\\\\)]',
-            'linux': '(/)(home)(/).*',
-        }
 
-        if path.platform == 'win32':
-            pattern = pattern_dictionary['win32']
-        else:
-            pattern = pattern_dictionary['linux']
+        pattern = r'C:\\Users\\[A-Z].*' if path.platform == 'win32' \
+                  else r'/home/[a-z].'
 
         result = re.search(pattern, user)
-        assert isinstance(result, type(re.search('', ''))) is True
+        assert result
 
     def directory_separator(self, path):
         slash_character = ''


### PR DESCRIPTION
# I have made things!

## Checklist

- [x] I have read [contributing guidelines](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTING.rst)
- [x] I'm sure that I did not unrelated changes in this pull request
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the [CHANGELOG.rst](https://github.com/lk-geimfari/mimesis/blob/master/CHANGELOG.rst)

## Related issues

- Closes #607
- Refs #607 

I've refactored the Path data provider using the [pathlib](https://docs.python.org/3/library/pathlib.html) library as suggested in #607.

In order to remove that strange loops over the `PLATFORMS` dictionary I have changed the internals of the `path.py` module: now the main keys are the platform strings (*linux*, *darwin*, *win32* and *win64*) and the only thing specified in the dictionary is the *home* path:

```
PLATFORMS = {
    'linux': {
        'home': '/home/',
    },
    'darwin': {
        'home': '/home/',
    },
    'win32': {
        'home': 'C:\\Users\\',
    },
    'win64': {
        'home': 'C:\\Users\\',
    },
}
```

I have introduced a private variable `_pathlib_home` that is a [PurePath](https://docs.python.org/3/library/pathlib.html?highlight=purepath#pathlib.PurePath) object ([PureWindowsPath](https://docs.python.org/3/library/pathlib.html?highlight=purepath#pathlib.PureWindowsPath) or [PurePosixPath](https://docs.python.org/3/library/pathlib.html?highlight=purepath#pathlib.PurePosixPath) depending on the specified platform). That object contains the path to the home directory, all the other paths are built from the *home* path, for instance:

```
def root(self) -> str:
    """Generate a root dir path.
    :return: Root dir.
    :Example:
        /
        """
        return str(self._pathlib_home.parent)

...

def user(self) -> str:
    """Generate a random user.
    :return: Path to user.
    :Example:
        /home/oretha
    """
    user = self.random.choice(USERNAMES)
    user = user.capitalize() if 'win' in self.platform else user.lower()
    return str(self._pathlib_home / user)
```

In the refactoring process I've noticed that the unit tests for the `path` module were wrong: I fixed the assert statements to have actual testing (see the second commit of this pull request).