### PR TITLE
Remove multiple_choice

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ Version 3.2.0
 
 - Pass seed to custom providers
 
+**Removed**:
+
+- Removed ``multiple_choice()`` in the ``random`` module because it was unusued and it could be replaced with ``random.choices``.
+
 
 Version 3.1.0
 -------------

--- a/mimesis/random.py
+++ b/mimesis/random.py
@@ -26,18 +26,6 @@ class Random(random_module.Random):
 
     """
 
-    def multiple_choice(self, seq: Sequence[Any], amount: int = 2) -> list:
-        """Multiple choices of elements from the sequence.
-
-        Choice an element from sequence ``seq``
-        in an amount of ``amount``.
-
-        :param seq: Sequence of elements.
-        :param amount: Amount of elements.
-        :return: List of elements.
-        """
-        return [self.choice(seq) for _ in range(amount)]
-
     def randints(self, amount: int = 3,
                  a: int = 1, b: int = 100) -> List[int]:
         """Generate list of random integers.

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -76,19 +76,6 @@ def test_custom_code(random):
     assert result == 'M262'
 
 
-@pytest.mark.parametrize(
-    'amount', [
-        2,
-        3,
-        4,
-    ],
-)
-def test_multiple_choice(random, amount):
-    seq = [x for x in range(8)]
-    result = random.multiple_choice(seq, amount)
-    assert len(result) == amount
-
-
 def test_get_random_item(random):
     result = get_random_item(Gender)
     assert result in Gender


### PR DESCRIPTION
# I have made things!

## Checklist

<!-- Please check everything that applies: -->

- [x] I have read [contributing guidelines](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTING.rst)
- [x] I'm sure that I did not unrelated changes in this pull request
- [ ] I have added my changes to the [CHANGELOG.rst](https://github.com/lk-geimfari/mimesis/blob/master/CHANGELOG.rst)

## Related issues

I have removed the function `multiple_choice()` from the random module. It wasn't used by any other function, but, anyway, I found its implementation useless because from Python >= 3.6 there is the [choices](https://docs.python.org/3/library/random.html#random.choices) function that does exactly the same thing.
