### PR TITLE
Generic dev

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Version 3.2.0
 - Added meta classes for providers for internal usage (see `#621 <https://github.com/lk-geimfari/mimesis/issues/621>`_.)
 - Added support for custom templates in ``Person().username()``
 - Added ``ItalianSpecProvider()``
+- Added builtin provider in Generic.
 
 **Fixed**:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Version 3.2.0
 - Added meta classes for providers for internal usage (see `#621 <https://github.com/lk-geimfari/mimesis/issues/621>`_.)
 - Added support for custom templates in ``Person().username()``
 - Added ``ItalianSpecProvider()``
-- Added builtin provider in Generic.
+- Added an implementation of a mechanism for automatically add a built-in provider for a current locale to Generic (see `#674 <https://github.com/lk-geimfari/mimesis/issues/674>`_).
 
 **Fixed**:
 

--- a/mimesis/providers/generic.py
+++ b/mimesis/providers/generic.py
@@ -134,7 +134,8 @@ class Generic(BaseDataProvider):
 
         :param cls: Custom provider.
         :return: None
-        :raises TypeError: if cls is not class.
+        :raises TypeError: if cls is not class or is not a subclass
+            of BaseProvider.
         """
         if inspect.isclass(cls):
             if not issubclass(cls, BaseProvider):

--- a/mimesis/providers/generic.py
+++ b/mimesis/providers/generic.py
@@ -5,6 +5,17 @@
 import inspect
 from typing import Any, List, Type
 
+from mimesis.builtins import (
+    BrazilSpecProvider,
+    DenmarkSpecProvider,
+    GermanySpecProvider,
+    ItalySpecProvider,
+    NetherlandsSpecProvider,
+    PolandSpecProvider,
+    RussiaSpecProvider,
+    UkraineSpecProvider,
+    USASpecProvider,
+)
 from mimesis.providers.address import Address
 from mimesis.providers.base import BaseDataProvider, BaseProvider
 from mimesis.providers.business import Business
@@ -48,6 +59,21 @@ class Generic(BaseDataProvider):
         self._text = Text
         self._food = Food
         self._science = Science
+
+        _spec_providers = {
+            'de': DenmarkSpecProvider,
+            'ge': GermanySpecProvider,
+            'en': USASpecProvider,
+            'it': ItalySpecProvider,
+            'nl': NetherlandsSpecProvider,
+            'pl': PolandSpecProvider,
+            'pt-br': BrazilSpecProvider,
+            'ru': RussiaSpecProvider,
+            'uk': UkraineSpecProvider,
+        }
+        if self.locale in _spec_providers:
+            self.add_provider(_spec_providers[self.locale])
+
         self.transport = Transport(seed=self.seed)
         self.code = Code(seed=self.seed)
         self.unit_system = UnitSystem(seed=self.seed)

--- a/tests/test_providers/test_generic.py
+++ b/tests/test_providers/test_generic.py
@@ -103,6 +103,11 @@ class TestGeneric(object):
         generic.add_provider(UnnamedProvider)
         assert generic.unnamedprovider.nothing() is None
 
+    def test_dir(self, generic):
+        providers = generic.__dir__()
+        for p in providers:
+            assert not p.startswith('_')
+
 
 class TestSeededGeneric(object):
 

--- a/tests/test_providers/test_generic.py
+++ b/tests/test_providers/test_generic.py
@@ -50,6 +50,15 @@ class TestGeneric(object):
         result = generic.code.isbn()
         assert result is not None
 
+    def test_base_spec_provider(self):
+        generic = Generic()
+        result = generic.usa_provider.ssn()
+        assert result is not None
+
+        generic = Generic(locale='it')
+        result = generic.italy_provider.fiscal_code()
+        assert result is not None
+
     def test_bad_argument(self, generic):
         with pytest.raises(AttributeError):
             _ = generic.bad_argument  # noqa
@@ -96,7 +105,6 @@ class TestGeneric(object):
 
 
 class TestSeededGeneric(object):
-    TIMES = 5
 
     @pytest.fixture
     def g1(self, seed):

--- a/tests/test_providers/test_generic.py
+++ b/tests/test_providers/test_generic.py
@@ -95,6 +95,9 @@ class TestGeneric(object):
         with pytest.raises(TypeError):
             generic.add_providers(Provider4)
 
+        with pytest.raises(TypeError):
+            generic.add_providers(3)
+
         class UnnamedProvider(BaseProvider):
             @staticmethod
             def nothing():


### PR DESCRIPTION
# I have made things!
## Checklist

- [x] I'm sure that I did not unrelated changes in this pull request
- [x] I have created at least one test case for the changes I have made
- [x] I have added my changes to the [CHANGELOG.rst](https://github.com/lk-geimfari/mimesis/blob/master/CHANGELOG.rst)

## Related issues

Format is:
- Closes #674 
- Refs #674 

Now the Generic provider comes with the builtin provider of the selected locale (if available). If no locale are specified, then it will have the default locale provider ('en').

Examples:

    >>> g = Generic()
    >>> g.usa_provider.personality()
    'INFP'

    >>> g = Generic(locale='ru')
    >>> g.russia_provider.in()
    '391922215031'

As I said in the referenced issue, I think that adding the builtin provider by default is the easiest thing to do. I think that adding more parameters such as `auto_add_builtin` or `builtin_custom_name` will bring unnecessary complexity to the API.
