### PR TITLE
Resolve Python 3.6+ deprecation warnings for collections.abc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
         - os: windows
           language: shell
           before_install:
-            - choco install python --version 3.6.7
+            - choco install python3 --version 3.6.8
             - python -m pip install --upgrade pip
           env: PATH=/c/Python36:/c/Python36/Scripts:$PATH
           name: "Python 3.6 on Windows 10"
@@ -37,7 +37,7 @@ matrix:
         - os: windows
           language: shell
           before_install:
-            - choco install python
+            - choco install python3 --version 3.7.5
             - python -m pip install --upgrade pip
           env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
           name: "Python 3.7 on Windows 10"

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -80,6 +80,7 @@ Patches and Suggestions
 -  Anphisa `(anphisa)`_
 -  Gary Donovan `(garyd203)`_
 -  Shanmuga Priya R `(Shanmugapriya03)`_
+-  Jeffrey Wilges `(jwilges)`_
 
 .. _(lk-geimfari): https://github.com/lk-geimfari
 .. _(sobolevn): https://github.com/sobolevn
@@ -137,3 +138,4 @@ Patches and Suggestions
 .. _(anphisa): https://github.com/Anphisa
 .. _(garyd203): https://github.com/garyd203
 .. _(Shanmugapriya03): https://github.com/Shanmugapriya03
+.. _(jwilges): https://github.com/jwilges

--- a/mimesis/providers/base.py
+++ b/mimesis/providers/base.py
@@ -2,7 +2,7 @@
 
 """Base data provider."""
 
-import collections
+import collections.abc
 import contextlib
 import functools
 import json
@@ -110,7 +110,7 @@ class BaseDataProvider(BaseProvider):
         :return: Updated dict.
         """
         for key, value in other.items():
-            if isinstance(value, collections.Mapping):
+            if isinstance(value, collections.abc.Mapping):
                 r = self._update_dict(initial.get(key, {}), value)
                 initial[key] = r
             else:

--- a/mimesis/providers/choice.py
+++ b/mimesis/providers/choice.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """Provides a random choice from items in a sequence."""
-import collections
+import collections.abc
 from typing import Any, Optional, Sequence, Union
 
 from mimesis.providers.base import BaseProvider
@@ -59,7 +59,7 @@ class Choice(BaseProvider):
         if not isinstance(length, int):
             raise TypeError('**length** must be integer.')
 
-        if not isinstance(items, collections.Sequence):
+        if not isinstance(items, collections.abc.Sequence):
             raise TypeError('**items** must be non-empty sequence.')
 
         if not items:


### PR DESCRIPTION
# Resolve `import collections` deprecation warnings
This brief patch resolves the deprecation warnings emitted by Python 3.6+ due to `import collections`.

I *suspect* this may be acceptable as-is, but if you desire Python 2.x backward compatibility (e.g. with a `try ... except ...` import) or unit tests, I can reformat the patch accordingly--though admittedly, unit testing that deprecation warnings are not emitted probably qualifies as pedantic.

## Sample warning
Projects importing `mimesis` will notice the deprecation warning during runtime, as seen in this `pytest` output for a test that imported the `choice` provider:

```
tests/sample.py::SampleTest::test_sample
  .tox/py38/lib/python3.8/site-packages/mimesis/providers/choice.py:62: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    if not isinstance(items, collections.Sequence):

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```

For now, in our project I simply have to ignore this warning when it is raised by `mimesis`, e.g. via `pytest.ini`:

```ini
[pytest]
filterwarnings =
    ignore::DeprecationWarning:mimesis.*:
```

## Checklist

- [x] I have read [contributing guidelines](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTING.rst)
- [x] I'm sure that I did not make unrelated changes in this pull request
- [ ] I have created at least one test case for the changes I have made
- [x] I have added myself to the [CONTRIBUTORS.rst](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTORS.rst)
- [ ] I have added my changes to the [CHANGELOG.rst](https://github.com/lk-geimfari/mimesis/blob/master/CHANGELOG.rst)

**NOTE:** *If any aspect of this patch warrants a test or changelog change, please let me know and I will re-submit accordingly.*

## Related issues

I did not find an open/related issue for this.