### PR TITLE
Bumped mypy-extensions to 0.4.3

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -236,10 +236,12 @@
         },
         "mypy-extensions": {
             "hashes": [
-                "sha256:a161e3b917053de87dbe469987e173e49fb454eca10ef28b48b384538cc11458"
+                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
+                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
             ],
-            "version": "==0.4.2"
+            "version": "==0.4.3"
         },
+
         "packaging": {
             "hashes": [
                 "sha256:28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47",


### PR DESCRIPTION
# I have made things!

## Checklist

- [ ] I'm sure that I did not unrelated changes in this pull request
- [ ] I have created at least one test case for the changes I have made
- [ ] I have added my changes to the [CHANGELOG.rst](https://github.com/lk-geimfari/mimesis/blob/master/CHANGELOG.rst)

## Related issues

Format is:
- Closes #759 
- Refs #759

I have manually updated the `mypy-extensions` entry to the 0.4.3 version in the `Pipfile.lock` in order to make the tests pass in Linux. 

The build still doesn't pass because of the Windows 10 environment with Python 3.7. I'm sorry but I'm not familiar with Windows so I can't reproduce it. 
