### PR TITLE
Pin Windows CI packages for python3 to latest 3.6 and 3.7 releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
         - os: windows
           language: shell
           before_install:
-            - choco install python --version 3.6.7
+            - choco install python3 --version 3.6.8
             - python -m pip install --upgrade pip
           env: PATH=/c/Python36:/c/Python36/Scripts:$PATH
           name: "Python 3.6 on Windows 10"
@@ -37,7 +37,7 @@ matrix:
         - os: windows
           language: shell
           before_install:
-            - choco install python
+            - choco install python3 --version 3.7.5
             - python -m pip install --upgrade pip
           env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
           name: "Python 3.7 on Windows 10"


### PR DESCRIPTION
# Pin Python 3 Windows (choco) packages on CI
I believe the "Python 3.7" Windows build is currently failing because the underlying `choco` package was bumped to Python 3.9.x, leaving the `PATH` incorrect. Since 3.6 and 3.7 are the targets on other platforms, I have pinned the Windows choco package requirements accordingly.

- [x] I have read [contributing guidelines](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTING.rst)
- [x] I'm sure that I did not make unrelated changes in this pull request
- [ ] ~I have created at least one test case for the changes I have made~

## Related issues

This references the comments made on #759 and #760.

## Noise Alert!

~I may need to force-push a few pull requests to verify Travis CI moves to passing (as I do not have branch commit access with you all upstream). I will post a comment when this is ready to merge.~

My first build attempt is a success. @lk-geimfari for when you get a chance, I'll update my other commit to build off this one as well so you can see it passing and get both changes merged. Thanks for the prompt replies yesterday.