### PR TITLE
Upgrade data provider "Numbers" (Fix #800)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,8 @@ Version 4.0.0
 
 .. note:: This version is still under development.
 
+.. warning:: This release (4.0.0) contains some insignificant but breaking changes in API
+
 **Added**:
 
 - Added an alias ``first_name()`` for ``Person().name()``
@@ -10,6 +12,10 @@ Version 4.0.0
 - Added method ``randstr()`` for class ``Random()``
 - Added method ``complexes()`` for provider ``Numbers()``
 - Added method ``matrix`` for provider ``Numbers()``
+- Added method ``integer`` for provider ``Numbers()``
+- Added method ``float`` for provider ``Numbers()``
+- Added method ``complex`` for provider ``Numbers()``
+- Added method ``decimal`` for provider ``Numbers()``
 - Added method ``ip_v4_object()`` and ``ip_v6_object`` for provider ``Internet()``. Now you can generate IP objects, not just strings.
 - Added new parameter ``port_range`` for method ``ip_v4()``
 - Added new parameter ``separator`` for method ``Cryptographic().mnemonic_phrase()``
@@ -26,7 +32,11 @@ Version 4.0.0
 
 **Removed**:
 
-- Removed the ``rating()`` function in the ``Numbers`` provider. It can be replaced with ``floats(end=5, n=0, rounding=1)[0]``.
+- Removed the ``rating()`` method from the ``Numbers`` provider. It can be replaced with ``float(end=5, n=0, precision=1)``.
+- Removed the ``primes()`` method from the ``Numbers`` provider.
+- Removed the ``digit()`` method from the ``Numbers`` provider. Use ``integer`` instead.
+- Removed the ``between()`` method from the ``Numbers`` provider. Use ``integer`` instead.
+- Removed ``rounding`` argument from ``float()``. Now it's ``precision``.
 
 Version 3.3.0
 -------------

--- a/mimesis/enums.py
+++ b/mimesis/enums.py
@@ -227,3 +227,4 @@ class NumTypes(Enum):
     FLOATS = 'floats'
     INTEGERS = 'integers'
     COMPLEXES = 'complexes'
+    DECIMALS = 'decimals'

--- a/mimesis/providers/numbers.py
+++ b/mimesis/providers/numbers.py
@@ -2,7 +2,8 @@
 
 """Provides data related to numbers."""
 
-from typing import Callable, List, Union
+from decimal import Decimal
+from typing import List
 
 from mimesis.enums import NumTypes
 from mimesis.providers.base import BaseProvider
@@ -18,17 +19,18 @@ class Numbers(BaseProvider):
 
         name = 'numbers'
 
-    def floats(self, start: float = 0, end: float = 1, n: int = 10,
-               rounding: int = 15) -> List[float]:
+    def floats(self, start: float = 0, end: float = 1,
+               n: int = 10, precision: int = 15) -> List[float]:
         """Generate a list of random float numbers.
 
         :param start: Start range.
         :param end: End range.
         :param n: Length of the list.
-        :param rounding: Max number of decimal digits.
+        :param precision: Round a number to a given
+            precision in decimal digits, default is 15.
         :return: The list of floating-point numbers.
         """
-        return [self.random.uniform(start, end, rounding) for _ in range(n)]
+        return [self.random.uniform(start, end, precision) for _ in range(n)]
 
     def integers(self, start: int = 0, end: int = 10,
                  n: int = 10) -> List[int]:
@@ -49,7 +51,7 @@ class Numbers(BaseProvider):
 
     def complexes(self, start_real: float = 0, end_real: float = 1,
                   start_imag: float = 0, end_imag: float = 1,
-                  rounding_real: int = 15, rounding_imag: int = 15,
+                  precision_real: int = 15, precision_imag: int = 15,
                   n: int = 10) -> List[complex]:
         """Generate a list of random complex numbers.
 
@@ -57,15 +59,28 @@ class Numbers(BaseProvider):
         :param end_real: End real range.
         :param start_imag: Start imaginary range.
         :param end_imag: End imaginary range.
-        :param rounding_real: Rounding real part.
-        :param rounding_imag: Roungind imaginary part.
+        :param precision_real:  Round a real part of
+            number to a given precision.
+        :param precision_imag:  Round the imaginary part of
+            number to a given precision.
         :param n: Length of the list.
         :return: A list of random complex numbers.
         """
         return [
-            complex(self.random.uniform(start_real, end_real, rounding_real),
-                    self.random.uniform(start_imag, end_imag, rounding_imag))
+            complex(self.random.uniform(start_real, end_real, precision_real),
+                    self.random.uniform(start_imag, end_imag, precision_imag))
             for _ in range(n)]
+
+    def decimals(self, start: float = 0.0,
+                 end: float = 1000.0, n: int = 10) -> List[Decimal]:
+        """Generate decimal number as Decimal objects
+
+        :param start: Start range.
+        :param end: End range.
+        :param n: Length of the list.
+        :return: A list of random decimal numbers.
+        """
+        return [Decimal(i) for i in self.floats(start, end, n)]
 
     def matrix(self, m: int = 10, n: int = 10,
                num_type: NumTypes = NumTypes.FLOATS, **kwargs) -> List[List]:
@@ -74,7 +89,7 @@ class Numbers(BaseProvider):
         :param m: Number of rows.
         :param n: Number of columns.
         :param num_type: NumTypes enum object.
-        :param **kwargs: Other specific arguments.
+        :param kwargs: Other specific arguments.
         :return: A matrix of random numbers.
         """
         key = self._validate_enum(num_type, NumTypes)
@@ -82,57 +97,32 @@ class Numbers(BaseProvider):
         method = getattr(self, key)
         return [method(**kwargs) for _ in range(m)]
 
-    @staticmethod
-    def primes(start: int = 1, end: int = 999) -> List[int]:
-        """Generate a list of prime numbers.
+    def integer(self, start: int = -1000, end: int = 1000) -> int:
+        """Generate random integer from start to end.
 
-        :param start: First value of range.
-        :param end: Last value of range.
-        :return: A list of prime numbers from start to end.
+        :param start: Start range.
+        :param end: End range.
+        :return: Integer.
         """
-        # TODO: It should generate random primes with passed length.
-        sieve_size = (end // 2 - 1) if end % 2 == 0 else (end // 2)
-        sieve = [True] * sieve_size
+        return self.random.randint(start, end)
 
-        primes = []  # list of primes
-        # add 2 to the list if it's in the given range
-        if end >= 2:
-            primes.append(2)
-        for i in range(sieve_size):
-            if sieve[i]:
-                value_at_i = i * 2 + 3
-                primes.append(value_at_i)
-                for j in range(i, sieve_size, value_at_i):
-                    sieve[j] = False
+    def float(self, start: float = -1000.0,
+              end: float = 1000.0, precision: int = 15):  # noqa: A003
+        """Generate random float number in range [start, end].
 
-        chop_index = 0
-        for i in range(len(primes)):
-            if primes[i] >= start:
-                chop_index = i
-                break
-        return primes[chop_index:]
-
-    def digit(self, to_bin: bool = False) -> Union[str, int]:
-        """Get a random digit.
-
-        :param to_bin: If True then convert to binary.
-        :return: Digit.
-
-        :Example:
-            4.
+        :param start: Start range.
+        :param end:  End range.
+        :param precision: Round a number to a given
+            precision in decimal digits, default is 15.
+        :return: Float.
         """
-        digit = self.random.randint(0, 9)
+        return self.random.uniform(start, end, precision)
 
-        if to_bin:
-            return bin(digit)
+    def decimal(self, start: float = -1000.0, end: float = 1000.0) -> Decimal:
+        """Generate random decimal number.
 
-        return digit
-
-    def between(self, minimum: int = 1, maximum: int = 1000) -> int:
-        """Generate a random number between minimum and maximum.
-
-        :param minimum: Minimum of range.
-        :param maximum: Maximum of range.
-        :return: Number.
+        :param start:  Start range.
+        :param end: End range.
+        :return: Decimal object.
         """
-        return self.random.randint(minimum, maximum)
+        return Decimal(self.float(start, end))

--- a/mimesis/providers/numbers.py
+++ b/mimesis/providers/numbers.py
@@ -19,6 +19,18 @@ class Numbers(BaseProvider):
 
         name = 'numbers'
 
+    def floating(self, start: float = -1000.0,
+                 end: float = 1000.0, precision: int = 15) -> float:
+        """Generate random float number in range [start, end].
+
+        :param start: Start range.
+        :param end:  End range.
+        :param precision: Round a number to a given
+            precision in decimal digits, default is 15.
+        :return: Float.
+        """
+        return self.random.uniform(start, end, precision)
+
     def floats(self, start: float = 0, end: float = 1,
                n: int = 10, precision: int = 15) -> List[float]:
         """Generate a list of random float numbers.
@@ -30,7 +42,16 @@ class Numbers(BaseProvider):
             precision in decimal digits, default is 15.
         :return: The list of floating-point numbers.
         """
-        return [self.random.uniform(start, end, precision) for _ in range(n)]
+        return [self.floating(start, end, precision) for _ in range(n)]
+
+    def integer(self, start: int = -1000, end: int = 1000) -> int:
+        """Generate random integer from start to end.
+
+        :param start: Start range.
+        :param end: End range.
+        :return: Integer.
+        """
+        return self.random.randint(start, end)
 
     def integers(self, start: int = 0, end: int = 10,
                  n: int = 10) -> List[int]:
@@ -49,6 +70,28 @@ class Numbers(BaseProvider):
         """
         return self.random.randints(n, start, end)
 
+    def complex_number(self, start_real: float = 0.0,
+                       end_real: float = 1.0,
+                       start_imag: float = 0.0,
+                       end_imag: float = 1.0,
+                       precision_real: int = 15,
+                       precision_imag: int = 15) -> complex:
+        """Generate random complex number.
+
+        :param start_real: Start real range.
+        :param end_real: End real range.
+        :param start_imag: Start imaginary range.
+        :param end_imag: End imaginary range.
+        :param precision_real:  Round a real part of
+            number to a given precision.
+        :param precision_imag:  Round the imaginary part of
+            number to a given precision.
+        :return: Complex numbers.
+        """
+        real_part = self.random.uniform(start_real, end_real, precision_real)
+        imag_part = self.random.uniform(start_imag, end_imag, precision_imag)
+        return complex(real_part, imag_part)
+
     def complexes(self, start_real: float = 0, end_real: float = 1,
                   start_imag: float = 0, end_imag: float = 1,
                   precision_real: int = 15, precision_imag: int = 15,
@@ -66,10 +109,28 @@ class Numbers(BaseProvider):
         :param n: Length of the list.
         :return: A list of random complex numbers.
         """
-        return [
-            complex(self.random.uniform(start_real, end_real, precision_real),
-                    self.random.uniform(start_imag, end_imag, precision_imag))
-            for _ in range(n)]
+        numbers = []
+        for _ in range(n):
+            numbers.append(
+                self.complex_number(
+                    start_real=start_real,
+                    end_real=end_real,
+                    start_imag=start_imag,
+                    end_imag=end_imag,
+                    precision_real=precision_real,
+                    precision_imag=precision_imag,
+                ),
+            )
+        return numbers
+
+    def decimal(self, start: float = -1000.0, end: float = 1000.0) -> Decimal:
+        """Generate random decimal number.
+
+        :param start:  Start range.
+        :param end: End range.
+        :return: Decimal object.
+        """
+        return Decimal.from_float(self.floating(start, end))
 
     def decimals(self, start: float = 0.0,
                  end: float = 1000.0, n: int = 10) -> List[Decimal]:
@@ -80,7 +141,7 @@ class Numbers(BaseProvider):
         :param n: Length of the list.
         :return: A list of random decimal numbers.
         """
-        return [Decimal(i) for i in self.floats(start, end, n)]
+        return [self.decimal(start, end) for _ in range(n)]
 
     def matrix(self, m: int = 10, n: int = 10,
                num_type: NumTypes = NumTypes.FLOATS, **kwargs) -> List[List]:
@@ -101,33 +162,3 @@ class Numbers(BaseProvider):
         kwargs.update({'n': n})
         method = getattr(self, key)
         return [method(**kwargs) for _ in range(m)]
-
-    def integer(self, start: int = -1000, end: int = 1000) -> int:
-        """Generate random integer from start to end.
-
-        :param start: Start range.
-        :param end: End range.
-        :return: Integer.
-        """
-        return self.random.randint(start, end)
-
-    def floating(self, start: float = -1000.0,
-                 end: float = 1000.0, precision: int = 15) -> float:
-        """Generate random float number in range [start, end].
-
-        :param start: Start range.
-        :param end:  End range.
-        :param precision: Round a number to a given
-            precision in decimal digits, default is 15.
-        :return: Float.
-        """
-        return self.random.uniform(start, end, precision)
-
-    def decimal(self, start: float = -1000.0, end: float = 1000.0) -> Decimal:
-        """Generate random decimal number.
-
-        :param start:  Start range.
-        :param end: End range.
-        :return: Decimal object.
-        """
-        return Decimal.from_float(self.floating(start, end))

--- a/mimesis/providers/numbers.py
+++ b/mimesis/providers/numbers.py
@@ -145,17 +145,17 @@ class Numbers(BaseProvider):
 
     def matrix(self, m: int = 10, n: int = 10,
                num_type: NumTypes = NumTypes.FLOATS, **kwargs) -> List[List]:
-        """Generate a m x n matrix with random numbers.
+        """Generate m x n matrix with random numbers.
 
         This method works with variety of types,
         so you can pass method-specific **kwargs.
 
-        See NumType enum object.
+        See code for more details.
 
         :param m: Number of rows.
         :param n: Number of columns.
         :param num_type: NumTypes enum object.
-        :param kwargs: Other specific arguments .
+        :param kwargs: Other method-specific arguments.
         :return: A matrix of random numbers.
         """
         key = self._validate_enum(num_type, NumTypes)

--- a/mimesis/providers/numbers.py
+++ b/mimesis/providers/numbers.py
@@ -86,10 +86,15 @@ class Numbers(BaseProvider):
                num_type: NumTypes = NumTypes.FLOATS, **kwargs) -> List[List]:
         """Generate a m x n matrix with random numbers.
 
+        This method works with variety of types,
+        so you can pass method-specific **kwargs.
+
+        See NumType enum object.
+
         :param m: Number of rows.
         :param n: Number of columns.
         :param num_type: NumTypes enum object.
-        :param kwargs: Other specific arguments.
+        :param kwargs: Other specific arguments .
         :return: A matrix of random numbers.
         """
         key = self._validate_enum(num_type, NumTypes)
@@ -106,8 +111,8 @@ class Numbers(BaseProvider):
         """
         return self.random.randint(start, end)
 
-    def float(self, start: float = -1000.0,
-              end: float = 1000.0, precision: int = 15):  # noqa: A003
+    def floating(self, start: float = -1000.0,
+                 end: float = 1000.0, precision: int = 15) -> float:
         """Generate random float number in range [start, end].
 
         :param start: Start range.
@@ -125,4 +130,4 @@ class Numbers(BaseProvider):
         :param end: End range.
         :return: Decimal object.
         """
-        return Decimal(self.float(start, end))
+        return Decimal.from_float(self.floating(start, end))

--- a/tests/test_providers/test_generic.py
+++ b/tests/test_providers/test_generic.py
@@ -160,7 +160,6 @@ class TestSeededGeneric(object):
 
     def test_generic_numbers(self, g1, g2):
         assert g1.numbers.integers() == g2.numbers.integers()
-        assert g1.numbers.digit() == g2.numbers.digit()
 
     def test_generic_path(self, g1, g2):
         assert g1.path.root() == g2.path.root()

--- a/tests/test_providers/test_numbers.py
+++ b/tests/test_providers/test_numbers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-import re
 import decimal
+import re
 
 import pytest
 
@@ -58,6 +58,13 @@ class TestNumbers(object):
         element = numbers.random.choice(result)
         assert isinstance(element, int)
 
+    @pytest.mark.parametrize(
+        'start, end', [
+            (1, 10),
+            (10, 20),
+            (20, 30),
+        ],
+    )
     def test_decimals(self, numbers, start, end):
         result = numbers.decimals(start=start, end=end)
 
@@ -127,18 +134,17 @@ class TestNumbers(object):
     def test_integer(self, numbers):
         result = numbers.integer(-100, 100)
         assert isinstance(result, int)
-        assert result >= -100
-        assert result <= 100
+        assert -100 <= result <= 100
 
     def test_float(self, numbers):
-        result = numbers.float(-100, 100, precision=15)
+        result = numbers.floating(-100, 100, precision=15)
         assert isinstance(result, float)
-        assert result >= -100
-        assert result <= 100
+        assert -100 <= result <= 100
         assert len(str(result).split('.')[1]) <= 15
 
     def test_decimal(self, numbers):
         result = numbers.decimal(-100, 100)
+        assert -100 <= result <= 100
         assert isinstance(result, decimal.Decimal)
 
 
@@ -155,6 +161,10 @@ class TestSeededNumbers(object):
     def test_floats(self, n1, n2):
         assert n1.floats() == n2.floats()
         assert n1.floats(n=5) == n2.floats(n=5)
+
+    def test_decimals(self, n1, n2):
+        assert n1.decimals() == n2.decimals()
+        assert n1.decimals(n=5) == n2.decimals(n=5)
 
     def test_integers(self, n1, n2):
         assert n1.integers() == n2.integers()
@@ -173,7 +183,7 @@ class TestSeededNumbers(object):
         assert n1.integer() == n2.integer()
 
     def test_float(self, n1, n2):
-        assert n1.float() == n2.float()
+        assert n1.floating() == n2.floating()
 
     def test_decimal(self, n1, n2):
         assert n1.decimal() == n2.decimal()

--- a/tests/test_providers/test_numbers.py
+++ b/tests/test_providers/test_numbers.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import re
+import decimal
 
 import pytest
 
@@ -36,7 +37,7 @@ class TestNumbers(object):
         result = numbers.floats(n=1000)
         assert len(result) == 1000
 
-        result = numbers.floats(rounding=4)
+        result = numbers.floats(precision=4)
         for e in result:
             assert len(str(e).split('.')[1]) <= 4
 
@@ -57,6 +58,16 @@ class TestNumbers(object):
         element = numbers.random.choice(result)
         assert isinstance(element, int)
 
+    def test_decimals(self, numbers, start, end):
+        result = numbers.decimals(start=start, end=end)
+
+        assert max(result) <= end
+        assert min(result) >= start
+        assert isinstance(result, list)
+
+        element = numbers.random.choice(result)
+        assert isinstance(element, decimal.Decimal)
+
     @pytest.mark.parametrize(
         'start_real, end_real, start_imag, end_imag', [
             (1.2, 10, 1, 2.4),
@@ -65,9 +76,9 @@ class TestNumbers(object):
         ],
     )
     def test_complexes(self, numbers,
-                         start_real, end_real, start_imag, end_imag):
+                       start_real, end_real, start_imag, end_imag):
         result = numbers.complexes(start_real, end_real,
-                                     start_imag, end_imag)
+                                   start_imag, end_imag)
         assert max(e.real for e in result) <= end_real
         assert min(e.real for e in result) >= start_real
         assert max(e.imag for e in result) <= end_imag
@@ -78,7 +89,7 @@ class TestNumbers(object):
         result = numbers.complexes(n=1000)
         assert len(result) == 1000
 
-        result = numbers.complexes(rounding_real=4, rounding_imag=6)
+        result = numbers.complexes(precision_real=4, precision_imag=6)
         for e in result:
             assert len(str(e.real).split('.')[1]) <= 4
             assert len(str(e.imag).split('.')[1]) <= 6
@@ -88,7 +99,7 @@ class TestNumbers(object):
         with pytest.raises(NonEnumerableError):
             numbers.matrix(num_type='int')
 
-        result = numbers.matrix(rounding=4)
+        result = numbers.matrix(precision=4)
         assert len(result) == 10
         for row in result:
             assert len(row) == 10
@@ -105,7 +116,7 @@ class TestNumbers(object):
                 assert isinstance(e, int)
 
         result = numbers.matrix(
-            num_type=NumTypes.COMPLEXES, rounding_real=4, rounding_imag=6)
+            num_type=NumTypes.COMPLEXES, precision_real=4, precision_imag=6)
         assert len(result) == 10
         for row in result:
             assert len(row) == 10
@@ -113,35 +124,22 @@ class TestNumbers(object):
                 assert len(str(e.real).split('.')[1]) <= 4
                 assert len(str(e.imag).split('.')[1]) <= 6
 
-    def test_primes(self, numbers):
-        result = numbers.primes()
-        assert len(result) == 168
-        assert isinstance(result, list)
-
-        result = numbers.primes(500, 500000)
-        assert len(result) == 41443
-        assert isinstance(result, list)
-
-        result = numbers.primes(start=10, end=200)[1]
-        assert result == 13
-
-    def test_digit(self, numbers):
-        digits = (
-            0, 1, 2,
-            3, 4, 5,
-            6, 7, 8,
-            9,
-        )
-        result = numbers.digit()
-        assert result in digits
-
-        result = numbers.digit(to_bin=True)
-        assert isinstance(result, str)
-
-    def test_between(self, numbers):
-        result = numbers.between(90, 100)
-        assert result >= 90
+    def test_integer(self, numbers):
+        result = numbers.integer(-100, 100)
+        assert isinstance(result, int)
+        assert result >= -100
         assert result <= 100
+
+    def test_float(self, numbers):
+        result = numbers.float(-100, 100, precision=15)
+        assert isinstance(result, float)
+        assert result >= -100
+        assert result <= 100
+        assert len(str(result).split('.')[1]) <= 15
+
+    def test_decimal(self, numbers):
+        result = numbers.decimal(-100, 100)
+        assert isinstance(result, decimal.Decimal)
 
 
 class TestSeededNumbers(object):
@@ -161,7 +159,7 @@ class TestSeededNumbers(object):
     def test_integers(self, n1, n2):
         assert n1.integers() == n2.integers()
         assert n1.integers(start=-999, end=999, n=10) == \
-            n2.integers(start=-999, end=999, n=10)
+               n2.integers(start=-999, end=999, n=10)
 
     def test_complexes(self, n1, n2):
         assert n1.complexes() == n2.complexes()
@@ -171,15 +169,11 @@ class TestSeededNumbers(object):
         assert n1.matrix() == n2.matrix()
         assert n1.matrix(n=5) == n2.matrix(n=5)
 
-    def test_digit(self, n1, n2):
-        assert n1.digit() == n2.digit()
-        assert n1.digit(to_bin=True) == n2.digit(to_bin=True)
+    def test_integer(self, n1, n2):
+        assert n1.integer() == n2.integer()
 
-    def test_between(self, n1, n2):
-        assert n1.between() == n2.between()
-        assert n1.between(minimum=42, maximum=2048) == \
-            n2.between(minimum=42, maximum=2048)
+    def test_float(self, n1, n2):
+        assert n1.float() == n2.float()
 
-    @pytest.mark.skip(reason='Method refactoring needed.')
-    def test_primes(self, n1, n2):
-        assert n1.primes() == n2.primes()
+    def test_decimal(self, n1, n2):
+        assert n1.decimal() == n2.decimal()

--- a/tests/test_providers/test_numbers.py
+++ b/tests/test_providers/test_numbers.py
@@ -101,7 +101,28 @@ class TestNumbers(object):
             assert len(str(e.real).split('.')[1]) <= 4
             assert len(str(e.imag).split('.')[1]) <= 6
 
+    @pytest.mark.parametrize(
+        'sr, er, si, ei, pr, pi', [
+            (1.2, 10, 1, 2.4, 15, 15),
+            (10.4, 20.0, 2.3, 10, 10, 10),
+            (20.3, 30.8, 2.4, 4.5, 12, 12),
+        ],
+    )
+    def test_complex_number(self, numbers, sr, er, si, ei, pr, pi):
+        result = numbers.complex_number(
+            start_real=sr,
+            end_real=er,
+            start_imag=si,
+            end_imag=ei,
+            precision_real=pr,
+            precision_imag=pi,
+        )
+        assert isinstance(result, complex)
+        assert len(str(result.real).split('.')[1]) <= pr
+        assert len(str(result.imag).split('.')[1]) <= pi
+
     def test_matrix(self, numbers):
+        # TODO: Rewrite it to cover all cases
 
         with pytest.raises(NonEnumerableError):
             numbers.matrix(num_type='int')
@@ -187,3 +208,6 @@ class TestSeededNumbers(object):
 
     def test_decimal(self, n1, n2):
         assert n1.decimal() == n2.decimal()
+
+    def test_complex_number(self, n1, n2):
+        assert n1.complex_number() == n2.complex_number()


### PR DESCRIPTION
Version 4.0.0
-------------

**This release (4.0.0) contains some insignificant but breaking changes in API**

**Added**:
- Added method ``complexes()`` for provider ``Numbers()``
- Added method ``matrix`` for provider ``Numbers()``
- Added method ``integer`` for provider ``Numbers()``
- Added method ``float`` for provider ``Numbers()``
- Added method ``complex`` for provider ``Numbers()``
- Added method ``decimal`` for provider ``Numbers()``

**Updated**:

- The ``floats()`` function in the ``Numbers`` provider now accepts arguments about the range of the generated float numbers and the rounding used. By default, it generates a list of ``n`` float numbers instead of a list of 10^n elements.

**Removed**:

- Removed the ``rating()`` method from the ``Numbers`` provider. It can be replaced with ``float(end=5, n=0, precision=1)``.
- Removed the ``primes()`` method from the ``Numbers`` provider.
- Removed the ``digit()`` method from the ``Numbers`` provider. Use ``integer`` instead.
- Removed the ``between()`` method from the ``Numbers`` provider. Use ``integer`` instead.
- Removed ``rounding`` argument from ``float()``. Now it's ``precision``.
