### PR TITLE
Add pytest-randomly seedsetting functionto Makefile

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -184,6 +184,19 @@ To run tests, simply:
 Check out logs of Travis CI or AppVeyor if tests were failed on creating
 PR, there you can find useful information.
 
+The tests are randomly shuffled by pytest-randomly. To rerun the tests with the previous seed use:
+
+.. code:: text
+
+    ) make test SEED=last
+
+If you want to specify a seed ahead of time use:
+
+.. code:: text
+
+    ) make test SEED=$int
+    
+
 Type checking
 ~~~~~~~~~~~~~
 

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -83,6 +83,9 @@ Patches and Suggestions
 -  Gary Donovan `(garyd203)`_
 -  Shanmuga Priya R `(Shanmugapriya03)`_
 -  Jeffrey Wilges `(jwilges)`_
+-  Tim Kreitner `(tabassco)`_
+
+
 
 .. _(lk-geimfari): https://github.com/lk-geimfari
 .. _(sobolevn): https://github.com/sobolevn
@@ -142,3 +145,4 @@ Patches and Suggestions
 .. _(Shanmugapriya03): https://github.com/Shanmugapriya03
 .. _(jwilges): https://github.com/jwilges
 .. _(jrast): https://github.com/jrast
+.. _(tabassco): https://github.com/tabassco

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,25 @@
 SHELL:=/usr/bin/env bash
 
+SEED = unspecified
+
+ifneq ("$(SEED)", "unspecified")
+RANDOM_SEED = --randomly-seed=$(SEED)
+endif
 
 .PHONY: help
 help:
 	@echo "Available options:"
 	@echo "........................................................"
-	@echo "clean-pyc    - remove Python file artifacts"
-	@echo "clean-build  - remove build artifacts"
-	@echo "clean        - remove build and Python file artifacts"
-	@echo "docs         - build Sphinx HTML documentation and open in browser"
-	@echo "test         - run tests quickly with the default Python"
-	@echo "type-check   - run mypy for checking types"
-	@echo "publish      - create dist and upload package to PyPI"
-	@echo "install      - install the package to the active Python's site-packages"
+	@echo "clean-pyc      - remove Python file artifacts"
+	@echo "clean-build    - remove build artifacts"
+	@echo "clean          - remove build and Python file artifacts"
+	@echo "docs           - build Sphinx HTML documentation and open in browser"
+	@echo "test           - run tests quickly with the default Python"
+	@echo "test SEED=last - rerun tests with identical seed for pytest-randomly"
+	@echo "test SEED=1234 - run tests with specified seed for pytest-randomly"
+	@echo "type-check     - run mypy for checking types"
+	@echo "publish        - create dist and upload package to PyPI"
+	@echo "install        - install the package to the active Python's site-packages"
 	@echo "........................................................"
 
 
@@ -42,7 +49,7 @@ clean: clean-pyc clean-build
 
 .PHONY: test
 test:
-	pytest --color=yes ./
+	pytest --color=yes $(RANDOM_SEED) ./
 	mypy mimesis/ tests/
 	make clean
 


### PR DESCRIPTION
# I have made things!

Hey there. This is my first pull request for an open source project. :)

## Checklist

<!-- Please check everything that applies: -->

- [x] I have read [contributing guidelines](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTING.rst)
- [x] I'm sure that I did not unrelated changes in this pull request
- [ ] I have created at least one test case for the changes I have made

- [x] I have added myself to the [CONTRIBUTORS.rst](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTORS.rst)

<!-- Uncomment this if documentation update required
- [ ] I have updated the documentation for the changes I have made
-->

<!-- Uncomment this if changelog update required
- [ ] I have added my changes to the [CHANGELOG.rst](https://github.com/lk-geimfari/mimesis/blob/master/CHANGELOG.rst)
-->

## Related issues

- Closes #468 


## Ideas

I've already described my ideas in my first draft in the issues thread. 

But what it boils down to:

Give the option to specify the --randomly-seed option from the Makefile to make easier use of this feature. 

I have updated the contributing guide to introduce the feature.
