### PR TITLE
Fix unicode support in Random.custom_code

### DIFF
--- a/mimesis/random.py
+++ b/mimesis/random.py
@@ -75,7 +75,6 @@ class Random(random_module.Random):
         """
         char_code = ord(char)
         digit_code = ord(digit)
-        code = bytearray(len(mask))
 
         if char_code == digit_code:
             raise ValueError('You cannot use the same '
@@ -86,6 +85,7 @@ class Random(random_module.Random):
             return int(self.random() * b) + a
 
         _mask = mask.encode()
+        code = bytearray(len(_mask))
         for i, p in enumerate(_mask):
             if p == char_code:
                 a = random_int(65, 91)  # A-Z

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -66,13 +66,16 @@ def test_uniform(random, precision):
     'mask, digit, char', [
         ('##-FA-@@', '#', '@'),
         ('**-AF-$$', '*', '$'),
+        ('**-š好-$$', '*', '$'),
     ],
 )
 def test_custom_code(random, mask, digit, char):
     result = random.custom_code(mask=mask, char=char, digit=digit)
-    digit, _, char = result.split('-')
+    digit, middle, char = result.split('-')
+    _, middle_mask, _ = mask.split('-')
     assert char.isalpha()
     assert digit.isdigit()
+    assert middle == middle_mask
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# I have made things!

## Checklist

- [x] I have read [contributing guidelines](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTING.rst)
- [x] I'm sure that I did not unrelated changes in this pull request
- [x] I have created at least one test case for the changes I have made

`random.Random.custom_code` raised `IndexError: bytearray index out of range` if `mask` contained characters beyond ASCII because the created `code` `bytearray` was shorter than the encoded `mask`.
This fixes the issue (and adds a test) that allows the whole Unicode in `mask` (still not in `char`/`digit` placeholders). In UTF-8 this is possible since characters beyond ASCII are encoded using bytes other than 32–126.