### PR TITLE
Fix Providing same seed is resulting in different results for `randstr` Issue:936

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -85,7 +85,7 @@ Patches and Suggestions
 -  Jeffrey Wilges `(jwilges)`_
 -  Tim Kreitner `(tabassco)`_
 -  Miroslav Šedivý `(eumiro)`_
-
+-  Thanarathanam `(Thanarathanam)`_
 
 
 .. _(lk-geimfari): https://github.com/lk-geimfari
@@ -148,3 +148,4 @@ Patches and Suggestions
 .. _(jrast): https://github.com/jrast
 .. _(tabassco): https://github.com/tabassco
 .. _(eumiro): https://github.com/eumiro
+.. _(Thanarathanam): https://github.com/Thanarathanam

--- a/mimesis/random.py
+++ b/mimesis/random.py
@@ -13,7 +13,6 @@ get a random item of the enum object.
 
 import os
 import random as random_module
-import secrets
 import string
 import uuid
 from typing import Any, List, Optional

--- a/mimesis/random.py
+++ b/mimesis/random.py
@@ -126,7 +126,9 @@ class Random(random_module.Random):
 
         _string = string.ascii_letters + string.digits
         _string = ''.join(
-            secrets.choice(_string) for _ in range(length)
+            _string[i] for i in self.randints(
+                length, 0, len(_string) - 1,
+            )
         )
         return _string
 

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -123,6 +123,22 @@ def test_randstr(random, length):
     assert len(result) == length
 
 
+def test_randstr_nonunique_with_same_seed(random):
+    random.seed(1)
+    firstSet = [random.randstr(unique=False) for _ in range(10)]
+    random.seed(1)
+    secondSet = [random.randstr(unique=False) for _ in range(10)]
+    assert firstSet == secondSet
+
+
+def test_randstr_nonunique_with_different_seed(random):
+    random.seed(1)
+    firstSet = [random.randstr(unique=False) for _ in range(10)]
+    random.seed(2)
+    secondSet = [random.randstr(unique=False) for _ in range(10)]
+    assert firstSet != secondSet
+
+
 @pytest.mark.parametrize(
     'count', [
         1000,


### PR DESCRIPTION
# I have made things!
I have modified random string generation logic in randstr method for non-unique strings. 

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have read [contributing guidelines](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTING.rst)
- [x] I'm sure that I did not unrelated changes in this pull request
- [x] I have created at least one test case for the changes I have made


- [x] I have added myself to the [CONTRIBUTORS.rst](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTORS.rst)


<!-- Uncomment this if documentation update required
- [ ] I have updated the documentation for the changes I have made
-->

<!-- Uncomment this if changelog update required
- [ ] I have added my changes to the [CHANGELOG.rst](https://github.com/lk-geimfari/mimesis/blob/master/CHANGELOG.rst)
-->

## Related issues
- Refs #936 
<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
