### PR TITLE
add Python 3.9 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6.x, 3.7.x, 3.8.x]
+        python-version: [3.6.x, 3.7.x, 3.8.x, 3.9.x]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+next version
+------------
+
+**Added**:
+
+- Added Python 3.9 support
+
+
 Version 4.1.2
 -------------
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -2,7 +2,7 @@ Contributing Guidelines
 -----------------------
 
 The `source code`_ and `issue tracker`_ are hosted on GitHub. *Mimesis*
-is tested against Python 3.6 through 3.8 on `Travis-CI`_ and `AppVeyor_`. Test coverage
+is tested against Python 3.6 through 3.9 on `GitHub Actions`_ and `AppVeyor_`. Test coverage
 is monitored with `Codecov`_.
 
 Dependencies
@@ -72,7 +72,6 @@ Example of annotated function:
 
 .. _source code: https://github.com/lk-geimfari/mimesis
 .. _issue tracker: https://github.com/lk-geimfari/mimesis/issues
-.. _Travis-CI: https://travis-ci.org/lk-geimfari/mimesis
 .. _AppVeyor: https://ci.appveyor.com/project/lk-geimfari/mimesis
 .. _Codecov: https://codecov.io/gh/lk-geimfari/mimesis
 .. _PEP8: https://www.python.org/dev/peps/pep-0008/
@@ -181,7 +180,7 @@ To run tests, simply:
 
     ⟩ make test
 
-Check out logs of Travis CI or AppVeyor if tests were failed on creating
+Check out logs of GitHub Actions or AppVeyor if tests were failed on creating
 PR, there you can find useful information.
 
 The tests are randomly shuffled by pytest-randomly. To rerun the tests with the previous seed use:
@@ -195,7 +194,7 @@ If you want to specify a seed ahead of time use:
 .. code:: text
 
     ) make test SEED=$int
-    
+
 
 Type checking
 ~~~~~~~~~~~~~
@@ -233,7 +232,7 @@ locale.
 Releases
 ~~~~~~~~
 
-We use **Travis CI** for automatically creating releases. The package
+We use **GitHub Actions** for automatically creating releases. The package
 will be published on PyPi after pushing the new **tag** to the master
 branch. The new release can be approved or disapproved by maintainers of
 this project. If the new release was disapproved, then maintainer should

--- a/setup.py
+++ b/setup.py
@@ -154,6 +154,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Operating System :: OS Independent',
         'Topic :: Software Development',


### PR DESCRIPTION
Added Python 3.9 support in GitHub Actions and `setup.py`. Fix docs (and replace Travis with Github Actions). 


## Checklist

<!-- Please check everything that applies: -->

- [x] I have read [contributing guidelines](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTING.rst)
- [x] I'm sure that I did not unrelated changes in this pull request
- [x] I have created at least one test case for the changes I have made

<!-- Uncomment this section if this is your very first PR to this repository
- [ ] I have added myself to the [CONTRIBUTORS.rst](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTORS.rst)
-->

<!-- Uncomment this if documentation update required
- [x] I have updated the documentation for the changes I have made
-->

<!-- Uncomment this if changelog update required
- [x] I have added my changes to the [CHANGELOG.rst](https://github.com/lk-geimfari/mimesis/blob/master/CHANGELOG.rst)
-->
