### PR TITLE
Fixed references to `make` in `CONTRIBUTING.rst`.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -98,7 +98,7 @@ To run tests, simply:
 
 .. code:: text
 
-    ⟩ make test
+    ⟩ poetry run pytest
 
 Check out logs of **GitHub Actions** or **AppVeyor** if tests were failed on creating
 PR, there you can find useful information.
@@ -107,24 +107,24 @@ The tests are randomly shuffled by ``pytest-randomly``. To rerun the tests with 
 
 .. code:: text
 
-    ) make test SEED=last
+    ) poetry run pytest --randomly-seed=last
 
 If you want to specify a seed ahead of time use:
 
 .. code:: text
 
-    ) make test SEED=$int
+    ) poetry run pytest --randomly-seed=$int
 
 
 Type checking
 ~~~~~~~~~~~~~
 
 After adding every feature you should run the type checking and make
-sure that everything is okay. You can do it using make:
+sure that everything is okay. You can do it using the following command:
 
 ::
 
-    ⟩ make type-check
+    ⟩ poetry run mypy mimesis/ tests/
 
 Code Review
 ~~~~~~~~~~~

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -88,6 +88,7 @@ Patches and Suggestions
 -  Emil Madsen `(Skeen)`_
 -  Michael Oliver `(michael0liver)`_
 -  Oleg Höfling `(hoefling)`_
+-  Nick Pope `(ngnpope)`_
 
 
 .. _(lk-geimfari): https://github.com/lk-geimfari
@@ -154,3 +155,4 @@ Patches and Suggestions
 .. _(michael0liver): https://github.com/aekt
 .. _(Skeen): https://github.com/Skeen
 .. _(hoefling): https://github.com/hoefling
+.. _(ngnpope): https://github.com/ngnpope


### PR DESCRIPTION
<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have read [contributing guidelines](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTING.rst)
- [x] I'm sure that I did not unrelated changes in this pull request
- [n/a] I have created at least one test case for the changes I have made
- [x] I have added myself to the [CONTRIBUTORS.rst](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTORS.rst)

<!-- Uncomment this if documentation update required
- [ ] I have updated the documentation for the changes I have made
-->

<!-- Uncomment this if changelog update required
- [ ] I have added my changes to the [CHANGELOG.rst](https://github.com/lk-geimfari/mimesis/blob/master/CHANGELOG.rst)
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

The `Makefile` was removed in v5.0.0 and `CONTRIBUTING.rst` has outdated references to `make test` and `make type-check`,