### PR TITLE
Updated `romanize()` to improve performance.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+Version 5.3.0
+-------------
+
+**Optimizations**:
+
+- Significantly improved performance of ``shortcuts.romanize()``
+
+
 Version 5.2.1
 -------------
 


### PR DESCRIPTION
Performance of the current implementation:

    In [1]: from mimesis.locales import Locale
       ...: from mimesis.shortcuts import romanize
       ...: string = "АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдеёжзийклмнопрстуфхцчшщъыьэюя"

    In [2]: %timeit romanize(string, locale=Locale.RU)
    10.3 µs ± 150 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

Making use of `str.maketrans()` and `str.translate()` avoids the need for the inclusion of ASCII characters in the translation table and improves the performance:

    In [2]: %timeit romanize(string, locale=Locale.RU)
    5.15 µs ± 74.9 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

It is also unnecessary to regenerate the translation table for every call to `romanize()`, so we can cache it for another boost:

    In [2]: %timeit romanize(string, locale=Locale.RU)
    2.67 µs ± 236 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have read [contributing guidelines](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTING.rst)
- [x] I'm sure that I did not unrelated changes in this pull request
- [ ] I have created at least one test case for the changes I have made

<!-- Uncomment this section if this is your very first PR to this repository
- [ ] I have added myself to the [CONTRIBUTORS.rst](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTORS.rst)
-->

<!-- Uncomment this if documentation update required
- [ ] I have updated the documentation for the changes I have made
-->

- [x] I have added my changes to the [CHANGELOG.rst](https://github.com/lk-geimfari/mimesis/blob/master/CHANGELOG.rst)

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
