### PR TITLE
Fix reseeding of random generator on `Generic`.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@ Version 5.3.0
 
 - Significantly improved performance of ``shortcuts.romanize()``
 
+**Fixed**:
+
+- Fix reseeding of the random generator of ``Generic``. This was a regression in v5.1.0. (See `#1150 <https://github.com/lk-geimfari/mimesis/issues/1150>`_).
+
 
 Version 5.2.1
 -------------

--- a/mimesis/providers/generic.py
+++ b/mimesis/providers/generic.py
@@ -117,6 +117,9 @@ class Generic(BaseProvider):
 
         :param seed: Seed for random.
         """
+        # Ensure that we reseed the random generator on Generic itself.
+        super().reseed(seed)
+
         for attr in self.__dir__():
             try:
                 provider = getattr(self, attr)

--- a/tests/test_providers/test_generic.py
+++ b/tests/test_providers/test_generic.py
@@ -7,9 +7,12 @@ from mimesis import BaseProvider, Generic
 class TestGeneric(object):
     def test_reseed(self, generic):
         generic.reseed(0xFFF)
+        number_1 = generic.random.uniform(0, 1000)
         address_1 = generic.address.address()
         generic.reseed(0xFFF)
+        number_2 = generic.random.uniform(0, 1000)
         address_2 = generic.address.address()
+        assert number_1 == number_2
         assert address_1 == address_2
 
     def test_base_person(self, generic):


### PR DESCRIPTION
Regression in 94eee4ebfd3c0bde76427e3b59fb65a5ac144595.

This ensures that the `random` instance on `Generic` itself is reseeded to allow reproducible use of standard random methods without using a subprovider. This also ensures that instances of `Generic` have isolated copies of the random number generator.

# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have read [contributing guidelines](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTING.rst)
- [x] I'm sure that I did not unrelated changes in this pull request
- [x] I have created at least one test case for the changes I have made

<!-- Uncomment this section if this is your very first PR to this repository
- [ ] I have added myself to the [CONTRIBUTORS.rst](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTORS.rst)
-->

<!-- Uncomment this if documentation update required
- [ ] I have updated the documentation for the changes I have made
-->

- [x] I have added my changes to the [CHANGELOG.rst](https://github.com/lk-geimfari/mimesis/blob/master/CHANGELOG.rst)

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

Closes #1150.

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
