### PR TITLE
Avoid infinite loop in `Datetime.bulk_create_datetimes` by checking for positive timedelta

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -90,6 +90,7 @@ Patches and Suggestions
 -  Oleg Höfling `(hoefling)`_
 -  Nick Pope `(ngnpope)`_
 -  Arul Prabakaran `(arulprabakaran)`_
+-  Florian Kroiß `(Wooza)`_
 
 
 .. _(lk-geimfari): https://github.com/lk-geimfari
@@ -158,3 +159,4 @@ Patches and Suggestions
 .. _(hoefling): https://github.com/hoefling
 .. _(ngnpope): https://github.com/ngnpope
 .. _(arulprabakaran): https://github.com/arulprabakaran
+.. _(Wooza): https://github.com/Wooza

--- a/mimesis/providers/date.py
+++ b/mimesis/providers/date.py
@@ -55,8 +55,9 @@ class Datetime(BaseDataProvider):
         :param date_end: End of the range.
         :param kwargs: Keyword arguments for :py:class:`datetime.timedelta`
         :return: List of datetime objects
-        :raises: ValueError: When ``date_start``/``date_end`` not passed and
-            when ``date_start`` larger than ``date_end``.
+        :raises: ValueError: When ``date_start``/``date_end`` not passed,
+            when ``date_start`` larger than ``date_end`` or when the given
+            keywords for `datetime.timedelta` represent a non-positive timedelta.
         """
         dt_objects = []
 
@@ -65,6 +66,9 @@ class Datetime(BaseDataProvider):
 
         if date_end < date_start:
             raise ValueError("date_start can not be larger than date_end")
+
+        if timedelta(**kwargs) <= timedelta():
+            raise ValueError("timedelta must be positive")
 
         while date_start <= date_end:
             date_start += timedelta(**kwargs)

--- a/tests/test_providers/test_datetime.py
+++ b/tests/test_providers/test_datetime.py
@@ -45,6 +45,11 @@ class TestDatetime:
         with pytest.raises(ValueError):
             _datetime.bulk_create_datetimes(None, None)
 
+        with pytest.raises(ValueError):
+            _datetime.bulk_create_datetimes(
+                date_start, date_start + datetime.timedelta(days=1)
+            )
+
     def test_year(self, _datetime):
         result = _datetime.year(minimum=2000, maximum=_datetime.CURRENT_YEAR)
         assert result >= 2000


### PR DESCRIPTION
Hi,

we were evaluating our [automated unit test generator](https://github.com/se2p/pynguin) on mimesis and found a bug in `Datetime.bulk_create_datetimes`. It is possible to call this method without `**kwargs` or with `**kwargs` that represent a non-positive timedelta. In such a case, the `while` loop in this method never terminates. I have added a simple check to verify that the used timedelta is positive and also added a test case for it.

## Checklist

- [x] I have read [contributing guidelines](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTING.rst)
- [x] I'm sure that I did not unrelated changes in this pull request
- [x] I have created at least one test case for the changes I have made

- [x] I have added myself to the [CONTRIBUTORS.rst](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTORS.rst)

Best regards
Florian