### PR TITLE
Improve random sampling performance.

### DIFF
--- a/mimesis/providers/choice.py
+++ b/mimesis/providers/choice.py
@@ -62,16 +62,15 @@ class Choice(BaseProvider):
         if length == 0:
             return self.random.choice(items)
 
-        data: t.List[str] = []
-        if unique and len(set(items)) < length:  # avoid an infinite while loop
+        if unique and len(set(items)) < length:  # Sanity check
             raise ValueError(
                 "There are not enough unique elements in "
                 "**items** to provide the specified **number**."
             )
-        while len(data) < length:
-            item = self.random.choice(items)
-            if (unique and item not in data) or not unique:
-                data.append(item)
+        if unique:
+            data: t.List[str] = self.random.sample(list(set(items)), k=length)
+        else:
+            data = self.random.choices(items, k=length)
 
         if isinstance(items, list):
             return data


### PR DESCRIPTION
The random selection in `mimesis.providers.choice.Choice.__call__` can be very slow for certain inputs.
For example, calling it with `(items="a" * 10000000 + "b", unique=True, length=2)` will cause the while loop to run extremely long, because it needs to sample two unique elements, but will sample 'a' many times. I have changed the code to use the faster implementations in the underlying random class, i.e., `sample` and `choices`.

For the above example, the old implementation took 8 seconds on my machine to compute, whereas the new implementation takes 0.23s.

I know that this input is probably not realistic, but I wanted to fix it nonetheless 😅 

## Checklist

- [x] I have read [contributing guidelines](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTING.rst)
- [x] I'm sure that I did not unrelated changes in this pull request
- [ ] I have created at least one test case for the changes I have made

I did not add further test cases, as the functionality is unchanged, but the existing tests still pass and the implementation should be faster in certain cases.
