### PR TITLE
Reseed sub providers when reseeding a provider

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -91,6 +91,7 @@ Patches and Suggestions
 -  Nick Pope `(ngnpope)`_
 -  Arul Prabakaran `(arulprabakaran)`_
 -  Florian Kroiß `(Wooza)`_
+-  Sven Steinbauer `(Svenito)`_
 
 
 .. _(lk-geimfari): https://github.com/lk-geimfari
@@ -160,3 +161,4 @@ Patches and Suggestions
 .. _(ngnpope): https://github.com/ngnpope
 .. _(arulprabakaran): https://github.com/arulprabakaran
 .. _(Wooza): https://github.com/Wooza
+.. _(Svenito): https://github.com/Svenito

--- a/mimesis/providers/base.py
+++ b/mimesis/providers/base.py
@@ -44,6 +44,14 @@ class BaseProvider:
         :param seed: Seed for random.
             When set to `None` the current system time is used.
         """
+        providers = [
+            sub_provider
+            for _, sub_provider in self.__dict__.items()
+            if isinstance(sub_provider, BaseProvider)
+        ]
+        for p in providers:
+            p.reseed(seed)
+
         self.seed = seed
         if seed is MissingSeed:
             # Remove casts after mypy will fix this inference:

--- a/tests/test_providers/test_internet.py
+++ b/tests/test_providers/test_internet.py
@@ -407,3 +407,11 @@ class TestSeededInternet:
 
     def test_public_dns(self, i1, i2):
         assert i1.public_dns() == i2.public_dns()
+
+    def test_reseed(self, i1, i2):
+        # Reseed with the same number should return same values
+        # issue #1313
+        i1.reseed(1)
+        ip = i1.http_request_headers()
+        i1.reseed(1)
+        assert ip == i1.http_request_headers()


### PR DESCRIPTION
This patch will iterate over the subproviders on a provider and reseed them. Otherwise providers that rely on other providers to generate data will not return consistent data when reseeded with the same value.

Refs #1313

# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [ x ] I have read [contributing guidelines](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTING.rst)
- [ x ] I'm sure that I did not unrelated changes in this pull request
- [ x ] I have created at least one test case for the changes I have made

- [ x ] I have added myself to the [CONTRIBUTORS.rst](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTORS.rst)


<!-- Uncomment this if documentation update required
- [ ] I have updated the documentation for the changes I have made
-->

<!-- Uncomment this if changelog update required
- [ ] I have added my changes to the [CHANGELOG.rst](https://github.com/lk-geimfari/mimesis/blob/master/CHANGELOG.rst)
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
