### PR TITLE
Fix spelling. Remove description from name entry

### DIFF
--- a/mimesis/data/sv/person.json
+++ b/mimesis/data/sv/person.json
@@ -2259,7 +2259,7 @@
   ],
   "political_views": [
     "Apatisk",
-    "Kimmunist",
+    "Kommunist",
     "Socialist",
     "Centerpartist",
     "Liberal",
@@ -2631,7 +2631,7 @@
     "Lantz",
     "Larsen",
     "Larsson",
-    "Laxman (Scandinavian surname)",
+    "Laxman",
     "Leijonhufvud",
     "Lennartsson",
     "Lestander",
@@ -3098,7 +3098,7 @@
   "views_on": [
     "Mycket negativ",
     "Negativ",
-    "Kompromissvilling",
+    "Kompromissvillig",
     "Neutral",
     "Positiv"
   ],


### PR DESCRIPTION
Fixes #1424

Also fixed some spelling errors.

## Spelling sources
https://svenska.se/tre/?sok=kompromissvillig&pz=1
https://svenska.se/tre/?sok=kommunist&pz=1