### PR TITLE
Add `pytest` entry in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,9 @@ sphinx-autodoc-typehints = "^1.19.2"
 [tool.poetry.plugins."pytest_randomly.random_seeder"]
 mimesis = "mimesis.entrypoints:pytest_randomly_reseed"
 
+[tool.poetry.plugins.pytest11]
+mimesis = "mimesis.plugins.pytest"
+
 [tool.pytest.ini_options]
 testpaths = [
     "mimesis",


### PR DESCRIPTION
Now it will be detected :)

As the next step, I propose to move tests from `pytest-mimesis`.