### PR TITLE
Fix type hints for key functions and field handlers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ Version next
 --------------
 
 - Fix file permissions in Windows.
+- Fix type hints for key functions and field handlers.
 
 Version 15.1.0
 --------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@ Version next
 --------------
 
 - Fix file permissions in Windows.
-- Fix type hints for key functions and field handlers.
+- Change type hints for key functions and field handlers.
 
 Version 15.1.0
 --------------

--- a/mimesis/schema.py
+++ b/mimesis/schema.py
@@ -32,7 +32,7 @@ __all__ = [
 ]
 
 FieldCache = dict[str, Callable[[Any], Any]]
-FieldHandler = Callable[[Random, Any], Any]
+FieldHandler = Callable[..., Any]
 RegisterableFieldHandler = tuple[str, FieldHandler]
 RegisterableFieldHandlers = Sequence[RegisterableFieldHandler]
 
@@ -192,7 +192,7 @@ class BaseField:
 
         # First, try to find a custom field handler.
         if name in self._handlers:
-            result = self._handlers[name](random, **kwargs)  # type: ignore
+            result = self._handlers[name](random, **kwargs)
         else:
             result = self._lookup_method(name)(**kwargs)
 
@@ -200,7 +200,7 @@ class BaseField:
             try:
                 # If a key function accepts two parameters
                 # then pass random instance to it.
-                return key(result, random)  # type: ignore
+                return key(result, random)
             except TypeError:
                 return key(result)
 
@@ -309,7 +309,7 @@ class Field(BaseField):
     Here is an example of how to use it:
 
         >>> _ = Field()
-        >>> _('username')
+        >>> _("username")
         Dogtag_1836
     """
 
@@ -325,14 +325,14 @@ class Fieldset(BaseField):
     Here is an example:
 
         >>> fieldset = Fieldset(i=100)
-        >>> fieldset('username')
+        >>> fieldset("username")
         ['pot_1821', 'vhs_1915', ..., 'reviewed_1849']
 
     You may also specify the number of iterations by passing the **i** keyword
     argument to the callable instance of fieldset:
 
         >>> fieldset = Fieldset()
-        >>> fieldset('username', i=2)
+        >>> fieldset("username", i=2)
         ['pot_1821', 'vhs_1915']
 
     When **i** is not specified, the reasonable default is used — **10**.

--- a/mimesis/types.py
+++ b/mimesis/types.py
@@ -57,4 +57,4 @@ Matrix = list[list[Number]]
 
 CallableSchema = Callable[[], JSON]
 
-Key = Callable[[Any], Any] | None
+Key = Callable[..., Any] | None


### PR DESCRIPTION
# I have made things!

Good: This removes the need to add type ignores when registering new handlers.
Bad: This allows basically any function. It is the equivalent of using Any.

Of the two bad options, it is better to not force devs to add type ignores.

Alternative considered:
I tried implementing a protocol. Neither mypy nor pyright properly handled all cases.

## Checklist

<!-- Please check everything that applies: -->

- [X] I have read [contributing guidelines](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTING.rst)
- [X] I'm sure that I did not unrelated changes in this pull request
- [ ] I have created at least one test case for the changes I have made
- [X] I have added my changes to the [CHANGELOG.rst](https://github.com/lk-geimfari/mimesis/blob/master/CHANGELOG.rst)

## Attempt with protocol

```python
from contextlib import nullcontext as does_not_raise
from random import Random
from typing import Any, Protocol
import pytest
from mimesis.schema import Field
class FieldHandler(Protocol):
    def __call__(self, random: Random, **kwargs: Any) -> Any: ...
    __name__: str
@pytest.fixture(name="field", scope="module")
def field_fixture() -> Field:
    return Field()
def use_handler(field: FieldHandler) -> None:
    field(Random(), kwarg1=1, kwarg2=2, bloop=0)
def test_handler_type_hint_passing_cases(field: Field) -> None:
    def no_keyword_args(random: Random, **kwargs: Any) -> Any: ...
    use_handler(no_keyword_args)
    def with_kwarg(random: Random, *, kwarg1: int, **kwargs: Any) -> Any: ...
    use_handler(with_kwarg)  # type: ignore # mypy false positive
    def kwarg_with_default(random: Random, kwarg1: int = 0, **kwargs: Any) -> Any: ...
    use_handler(kwarg_with_default)
def test_handler_type_hint_failing_cases(field: Field) -> None:
    def missing_positional_arg(**kwargs: Any) -> Any: ...
    with pytest.raises(TypeError):
        use_handler(missing_positional_arg)  # type: ignore
    def positional_arg_wrong_type(not_random: int, **kwargs: Any) -> Any: ...
    with does_not_raise():
        use_handler(positional_arg_wrong_type)  # type: ignore
    def missing_kwargs(random: Random) -> Any: ...
    with pytest.raises(TypeError):
        use_handler(missing_kwargs)  # type: ignore
    def extra_positional_arg(random: Random, extra_arg: int, **kwargs: Any) -> Any: ...
    with pytest.raises(TypeError):
        use_handler(extra_positional_arg)  # type: ignore # pyright false negative
```