### PR TITLE
feat: add e164 parameter to phone_number for E.164 format output

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -98,6 +98,7 @@ Patches and Suggestions
 - Watheq Alshowaiter `(watheqAlshowaiter)`_
 - Zayed Alsaidi `(zayedalsaidi)`_
 - Muayyad AlSadi `(muayyadalsadi)`_
+- Rodrigo Nogueira `(rodrigobnogueira)`_
 
 
 .. _(lk-geimfari): https://github.com/lk-geimfari
@@ -174,4 +175,5 @@ Patches and Suggestions
 .. _(watheqAlshowaiter): https://github.com/watheqAlshowaiter
 .. _(yah04dev): https://github.com/yah04dev
 .. _(muayyadalsadi): https://github.com/muayyad-alsadi
+.. _(rodrigobnogueira): https://github.com/rodrigobnogueira
 

--- a/mimesis/providers/person.py
+++ b/mimesis/providers/person.py
@@ -480,15 +480,22 @@ class Person(BaseDataProvider):
         languages: list[str] = self._extract(["language"])
         return self.random.choice(languages)
 
-    def phone_number(self, mask: str = "", placeholder: str = "#") -> str:
+    def phone_number(
+        self,
+        mask: str = "",
+        placeholder: str = "#",
+        e164: bool = False,
+    ) -> str:
         """Generates a random phone number.
 
         :param mask: Mask for formatting number.
         :param placeholder: A placeholder for a mask (default is #).
+        :param e164: If True, returns phone number in E.164 format (e.g., +14155552671).
         :return: Phone number.
 
         :Example:
-            +7-(963)-409-11-22.
+            Default: +7-(963)-409-11-22
+            E.164: +79634091122
         """
         if not mask:
             code = self.random.choice(CALLING_CODES)
@@ -496,7 +503,10 @@ class Person(BaseDataProvider):
             masks = self._extract(["telephone_fmt"], default=[default])
             mask = self.random.choice(masks)
 
-        return self.random.generate_string_by_mask(mask=mask, digit=placeholder)
+        result = self.random.generate_string_by_mask(mask=mask, digit=placeholder)
+        if e164:
+            return "+" + "".join(c for c in result if c.isdigit())
+        return result
 
     def telephone(self, *args: t.Any, **kwargs: t.Any) -> str:
         """An alias for :meth:`~.phone_number`."""

--- a/tests/test_providers/test_localized/test_person.py
+++ b/tests/test_providers/test_localized/test_person.py
@@ -206,6 +206,27 @@ class TestPerson:
         head = result.split(" ")[0]
         assert head == "+5"
 
+    def test_telephone_e164(self, _person):
+        result = _person.telephone(e164=True)
+        assert re.match(
+            r"^\+\d+$", result
+        ), f"E.164 format should be +digits, got: {result}"
+        assert len(result) >= 8, "E.164 number should have at least 7 digits plus +"
+
+        mask = "+1 (555)-123-4567"
+        result = _person.telephone(mask=mask, e164=True)
+        assert result == "+15551234567"
+
+        mask_with_separators = "+1-(###)-###-####"
+        result_e164 = _person.telephone(mask=mask_with_separators, e164=True)
+        assert re.match(
+            r"^\+\d+$", result_e164
+        ), f"Should be E.164 format, got: {result_e164}"
+        result_default = _person.telephone(mask=mask_with_separators, e164=False)
+        assert (
+            "-" in result_default or "(" in result_default
+        ), f"Default should have separators: {result_default}"
+
     @pytest.mark.parametrize(
         "gender",
         [
@@ -407,6 +428,7 @@ class TestSeededPerson:
         assert p1.telephone(mask="(x)-xx-xxx", placeholder="x") == p2.telephone(
             mask="(x)-xx-xxx", placeholder="x"
         )
+        assert p1.telephone(e164=True) == p2.telephone(e164=True)
 
     def test_surname(self, p1, p2):
         assert p1.surname() == p2.surname()


### PR DESCRIPTION
# I have made things!

## Checklist

- [x] I have read [contributing guidelines](https://github.com/lk-geimfari/mimesis/blob/master/CODE_OF_CONDUCT.md)
- [x] I'm sure that I did not unrelated changes in this pull request
- [x] I have created at least one test case for the changes I have made
- [x] I have added myself to the [CONTRIBUTORS.rst](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTORS.rst)
- [x] I have updated the documentation for the changes I have made

## Related issues

- Closes #1635

## Description

Adds an optional `e164` parameter to the `phone_number()` method in the Person provider. When `e164=True`, the method returns phone numbers in E.164 international format (e.g., `+14155552671`) by stripping all non-digit characters except the leading plus sign.

**Usage:**
```python
from mimesis import Person
person = Person()
person.phone_number(e164=True)  # Returns: +14155552671
```
