### PR TITLE
fix: resolve field aliases before custom handler lookup

### DIFF
--- a/mimesis/schema.py
+++ b/mimesis/schema.py
@@ -122,9 +122,6 @@ class BaseField:
         :return: Callable object.
         :raise FieldError: When field is invalid.
         """
-        # Check if the field is defined in aliases
-        name = self.aliases.get(name, name)
-
         # Support additional delimiters
         name = re.sub(r"[/:\s]", ".", name)
 
@@ -200,6 +197,10 @@ class BaseField:
             raise FieldError
 
         random = self.get_random_instance()
+
+        # Resolve the alias before the lookup, so that aliases
+        # can point at custom field handlers as well.
+        name = self.aliases.get(name, name)
 
         # First, try to find a custom field handler.
         if name in self._handlers:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -527,6 +527,17 @@ def test_field_aliasing(default_field):
         default_field("🇺🇸")
 
 
+def test_field_aliasing_custom_handler(default_field):
+    def custom_handler(random, **kwargs):
+        return "custom"
+
+    default_field.register_handler("bloop", custom_handler)
+    default_field.aliases = {"zoop": "bloop"}
+
+    assert default_field("bloop") == "custom"
+    assert default_field("zoop") == "custom"
+
+
 @pytest.mark.parametrize(
     "aliases",
     [

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -534,8 +534,14 @@ def test_field_aliasing_custom_handler(default_field):
     default_field.register_handler("bloop", custom_handler)
     default_field.aliases = {"zoop": "bloop"}
 
-    assert default_field("bloop") == "custom"
-    assert default_field("zoop") == "custom"
+    try:
+        assert default_field("bloop") == "custom"
+        assert default_field("zoop") == "custom"
+    finally:
+        # The fixture is module-scoped, so the state must be
+        # restored to not affect the other tests.
+        default_field.unregister_handler("bloop")
+        default_field.aliases.clear()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# I have made things!

An alias pointing at a registered custom field handler raised `FieldError`: `perform()` checked `self._handlers` with the raw name, and only `_lookup_method()` resolved aliases — so an aliased custom handler never matched and fell through to the provider lookup. Alias resolution now happens in `perform()` before the handler check, so aliases work for both built-in fields and custom handlers.

## Checklist

- [x] I have read [contributing guidelines](https://github.com/lk-geimfari/mimesis/blob/master/CONTRIBUTING.rst)
- [x] I'm sure that I did not unrelated changes in this pull request
- [x] I have created at least one test case for the changes I have made

## Related issues

- Closes #1514
