### PR TITLE
Add Schema.from_typed_dict to build a schema from a TypedDict

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+Version 21.1.0
+--------------
+
+- Added :meth:`Schema.from_typed_dict() <mimesis.schema.Schema.from_typed_dict>` to build a schema directly from a :class:`typing.TypedDict`. Keys are resolved by name (falling back to the annotated type), nested ``TypedDict`` annotations are expanded recursively, and the ``Annotated``, ``Required``, ``NotRequired`` and ``Optional`` wrappers are unwrapped. See (`#1579 <https://github.com/lk-geimfari/mimesis/issues/1579>`_).
+- Added :meth:`Field.can_resolve() <mimesis.schema.BaseField.can_resolve>` to check whether a field name can be resolved to a value.
+
 Version 21.0.0
 --------------
 

--- a/docs/schema.rst
+++ b/docs/schema.rst
@@ -273,6 +273,78 @@ The final result will look like this:
 
 That's it! You've just generated structured data using Mimesis.
 
+.. _schema_from_typed_dict:
+
+Generating From a TypedDict
+---------------------------
+
+.. versionadded:: 21.1.0
+
+If you already describe your records with a :class:`typing.TypedDict`, you can
+build a schema directly from it with :meth:`~mimesis.schema.Schema.from_typed_dict`
+instead of writing the schema definition by hand.
+
+Every key of the ``TypedDict`` becomes a key of each generated record. Values
+are produced by resolving the key against the data providers — the same lookup
+used by :class:`~mimesis.schema.Field` — so a key named ``email`` yields a real
+email address:
+
+.. code-block:: python
+
+    >>> from typing import TypedDict
+    >>> from mimesis import Schema
+
+    >>> class User(TypedDict):
+    ...     name: str
+    ...     email: str
+    ...     age: int
+
+    >>> schema = Schema.from_typed_dict(User, iterations=2)
+    >>> schema.create()
+    [{'name': 'Cordell', 'email': 'exposure1874@example.org', 'age': 42}, ...]
+
+When a key does not match any provider method, the annotated type is used to
+pick a generator instead (``int`` → ``integer_number``, ``float`` →
+``float_number``, ``bool`` → ``boolean``, ``str`` → ``word``). Nested
+``TypedDict`` annotations are expanded recursively, and the ``Annotated``,
+``Required``, ``NotRequired`` and ``Optional`` wrappers are unwrapped
+automatically:
+
+.. code-block:: python
+
+    >>> from typing import NotRequired, TypedDict
+
+    >>> class Address(TypedDict):
+    ...     city: str
+    ...     country: str
+
+    >>> class Profile(TypedDict):
+    ...     username: str
+    ...     age: int
+    ...     nickname: NotRequired[str]
+    ...     address: Address
+
+    >>> Schema.from_typed_dict(Profile, iterations=1).create()
+    [{'username': 'wrapped_1974', 'age': 55, 'nickname': 'apnic', 'address': {'city': 'Reno', 'country': 'Aruba'}}]
+
+For full control over locale, seeding, or keys that require custom generation,
+pass your own :class:`~mimesis.schema.Field`. A key that can be resolved neither
+by name nor by type needs a registered handler:
+
+.. code-block:: python
+
+    >>> from mimesis import Field
+
+    >>> class Record(TypedDict):
+    ...     external_id: str
+
+    >>> field = Field()
+    >>> field.register_handler(
+    ...     "external_id", lambda random, **kwargs: random.randint(1, 100)
+    ... )
+    >>> Schema.from_typed_dict(Record, field=field, iterations=1).create()
+    [{'external_id': 87}]
+
 .. _key_functions:
 
 Key Functions and Transformations

--- a/mimesis/schema.py
+++ b/mimesis/schema.py
@@ -1,13 +1,22 @@
 """Implements classes for generating data by schema."""
 
 import csv
+import importlib
 import inspect
 import json
 import pickle
 import re
+import types
 from collections.abc import Callable, Iterator, Sequence
 from pathlib import Path
-from typing import Any
+from typing import (
+    Any,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+    is_typeddict,
+)
 
 from mimesis.exceptions import (
     AliasesTypeError,
@@ -139,6 +148,25 @@ class BaseField:
             self._cache[name] = method
 
         return self._cache[name]
+
+    def can_resolve(self, name: str) -> bool:
+        """Return whether ``name`` can be resolved to a value.
+
+        A name is resolvable when a custom handler is registered for it (see
+        :meth:`register_handler`) or when it matches a method of one of the
+        supported data providers.
+
+        :param name: The field name.
+        :return: ``True`` if the name is resolvable, ``False`` otherwise.
+        """
+        if name in self._handlers:
+            return True
+
+        try:
+            self._lookup_method(name)
+        except FieldError:
+            return False
+        return True
 
     def _validate_aliases(self) -> bool:
         """Validate aliases."""
@@ -436,6 +464,119 @@ class SchemaContext:
         self.custom = custom or {}
 
 
+# ``Required``/``NotRequired`` live in ``typing`` on Python 3.11+ and in
+# ``typing_extensions`` on older versions. Collect whichever are importable so
+# ``TypedDict`` field qualifiers can be stripped regardless of Python version.
+_TYPED_DICT_QUALIFIERS: set[Any] = set()
+for _module_name in ("typing", "typing_extensions"):
+    try:
+        _module = importlib.import_module(_module_name)
+    except ImportError:  # pragma: no cover
+        continue
+    for _qualifier_name in ("Required", "NotRequired"):
+        _qualifier = getattr(_module, _qualifier_name, None)
+        if _qualifier is not None:
+            _TYPED_DICT_QUALIFIERS.add(_qualifier)
+
+# Both the ``typing.Union`` and the PEP 604 (``X | Y``) union forms.
+_UNION_ORIGINS = (Union, types.UnionType)
+
+# Providers used to generate a value when a ``TypedDict`` key cannot be
+# resolved to a data-provider method by its name and we fall back to its type.
+_TYPE_FALLBACKS: dict[type, str] = {
+    bool: "boolean",
+    int: "integer_number",
+    float: "float_number",
+    str: "word",
+}
+
+
+def _unwrap_annotation(annotation: Any) -> Any:
+    """Strip typing wrappers that do not affect data generation.
+
+    Removes ``Annotated``, ``Required``, ``NotRequired`` and ``Optional``
+    (i.e. ``Union[T, None]``) wrappers, returning the underlying type.
+
+    :param annotation: A type annotation.
+    :return: The unwrapped annotation.
+    """
+    # For an Annotated type, the underlying type is stored in its origin.
+    if hasattr(annotation, "__metadata__"):
+        return _unwrap_annotation(annotation.__origin__)
+
+    origin = get_origin(annotation)
+
+    # Strip the TypedDict Required and NotRequired qualifiers.
+    if origin in _TYPED_DICT_QUALIFIERS:
+        return _unwrap_annotation(get_args(annotation)[0])
+
+    # Strip an optional type, i.e. a two-member union with None.
+    if origin in _UNION_ORIGINS:
+        non_none = [arg for arg in get_args(annotation) if arg is not type(None)]
+        if len(non_none) == 1:
+            return _unwrap_annotation(non_none[0])
+
+    return annotation
+
+
+def _typed_dict_definition(
+    typed_dict: type,
+    field: "Field",
+) -> CallableSchema:
+    """Build a callable schema definition from a ``TypedDict``.
+
+    :param typed_dict: A ``TypedDict`` subclass.
+    :param field: The field used to generate values.
+    :return: A callable that returns a single record.
+    """
+    hints = get_type_hints(typed_dict, include_extras=True)
+    generators = {
+        key: _field_generator(key, annotation, field)
+        for key, annotation in hints.items()
+    }
+
+    def definition() -> JSON:
+        return {key: generate() for key, generate in generators.items()}
+
+    return definition
+
+
+def _field_generator(
+    key: str,
+    annotation: Any,
+    field: "Field",
+) -> Callable[[], Any]:
+    """Return a zero-argument callable that generates a value for ``key``.
+
+    A key is first resolved against the data providers by its name (so a key
+    named ``email`` yields a real email address). Nested ``TypedDict``
+    annotations are expanded recursively. When the name cannot be resolved, the
+    annotated type is used to pick a sensible generator.
+
+    :param key: The ``TypedDict`` key.
+    :param annotation: The annotation of the key.
+    :param field: The field used to generate values.
+    :return: A callable generating a value for the key.
+    :raises FieldError: If the key can be resolved neither by name nor by type.
+    """
+    core = _unwrap_annotation(annotation)
+
+    if is_typeddict(core):
+        return _typed_dict_definition(core, field)
+
+    # Prefer semantic, name-based resolution (a registered custom handler or a
+    # data-provider method matching the key name).
+    if field.can_resolve(key):
+        return lambda: field(key)
+
+    # Fall back to the annotated type for keys without a matching provider.
+    fallback = _TYPE_FALLBACKS.get(core)
+    if fallback is not None:
+        return lambda: field(fallback)
+
+    raise FieldError(key)
+
+
 class Schema:
     """Class which returns a list of filled schemas."""
 
@@ -472,6 +613,79 @@ class Schema:
         self.iterations = iterations
         self._transformers: list[SchemaTransformer] = []
         self._custom_context: dict[str, Any] = {}
+
+    @classmethod
+    def from_typed_dict(
+        cls,
+        typed_dict: type,
+        *,
+        field: "Field | None" = None,
+        locale: Locale = Locale.DEFAULT,
+        iterations: int = 10,
+        seed: Seed = MissingSeed,
+    ) -> "Schema":
+        """Create a schema from a :class:`typing.TypedDict`.
+
+        Every key of **typed_dict** becomes a key of each generated record.
+        Values are produced by resolving the key against the data providers —
+        the very same lookup used by :class:`Field` — so a key named ``email``
+        yields a real email address, ``username`` a username, and so on.
+
+        When a key does not match any provider method, its annotated type is
+        used to pick a generator instead (``int`` → ``integer_number``,
+        ``float`` → ``float_number``, ``bool`` → ``boolean``, ``str`` →
+        ``word``). Nested ``TypedDict`` annotations are expanded recursively,
+        and the ``Annotated``, ``Required``, ``NotRequired`` and ``Optional``
+        wrappers are transparently unwrapped.
+
+        Example::
+
+            >>> from typing import TypedDict
+            >>> from mimesis import Schema
+            >>>
+            >>> class User(TypedDict):
+            ...     name: str
+            ...     email: str
+            ...     age: int
+            >>>
+            >>> schema = Schema.from_typed_dict(User, iterations=2)
+            >>> schema.create()  # doctest: +SKIP
+            [{'name': 'Cythia', 'email': 'wed1841@example.com', 'age': 42}, ...]
+
+        Keys that can be resolved neither by name nor by type require a custom
+        field handler; register it on a :class:`Field` and pass it explicitly::
+
+            >>> from mimesis import Field
+            >>>
+            >>> class Record(TypedDict):
+            ...     external_id: str
+            >>>
+            >>> field = Field()
+            >>> field.register_handler(
+            ...     "external_id", lambda random, **kwargs: random.randint(1, 100)
+            ... )
+            >>> schema = Schema.from_typed_dict(Record, field=field)
+
+        :param typed_dict: A ``TypedDict`` subclass describing each record.
+        :param field: The field used to generate values. When omitted, a new
+            :class:`Field` is created from **locale** and **seed**.
+        :param locale: Locale for the default field (ignored when **field** is
+            given).
+        :param iterations: Number of records to generate.
+        :param seed: Seed for the default field (ignored when **field** is
+            given).
+        :return: Schema instance.
+        :raises TypeError: If **typed_dict** is not a ``TypedDict`` subclass.
+        :raises FieldError: If a key can be resolved neither by name nor type.
+        """
+        if not is_typeddict(typed_dict):
+            raise TypeError(f"{typed_dict!r} is not a TypedDict subclass.")
+
+        if field is None:
+            field = Field(locale=locale, seed=seed)
+
+        definition = _typed_dict_definition(typed_dict, field)
+        return cls(schema=definition, iterations=iterations, seed=seed)
 
     def _apply_transformers(self, item: JSON, ctx: SchemaContext) -> JSON:
         """Apply all transformers to an item.

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4,9 +4,20 @@ import pickle
 import re
 import unicodedata
 from collections.abc import Iterator
-from typing import TYPE_CHECKING
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    TypedDict,
+    get_type_hints,
+)
 
 import pytest
+
+
+try:
+    from typing import NotRequired
+except ImportError:  # Python 3.10
+    from typing_extensions import NotRequired
 
 from mimesis.enums import Gender
 from mimesis.exceptions import (
@@ -618,3 +629,120 @@ def test_schema_context():
     assert ctx.index == 5
     assert ctx.iteration == 6
     assert ctx.custom["test"] == "value"
+
+
+class Address(TypedDict):
+    city: str
+    country: str
+
+
+class User(TypedDict):
+    name: str
+    email: str
+    username: str
+    age: int
+    score: float
+    active: bool
+    nickname: NotRequired[str]
+    note: str | None
+    tagged: Annotated[int, "meta"]
+    address: Address
+
+
+def test_from_typed_dict_create():
+    schema = Schema.from_typed_dict(User, iterations=5, seed=0xFF)
+    data = schema.create()
+
+    assert len(data) == 5
+    for item in data:
+        assert set(item) == set(get_type_hints(User))
+        assert isinstance(item["name"], str)
+        assert isinstance(item["email"], str)
+        # ``bool`` must not be treated as ``int``.
+        assert isinstance(item["age"], int) and not isinstance(item["age"], bool)
+        assert isinstance(item["score"], float)
+        assert isinstance(item["active"], bool)
+        assert isinstance(item["tagged"], int)
+        assert isinstance(item["nickname"], str)
+        assert isinstance(item["note"], str)
+        assert isinstance(item["address"], dict)
+        assert set(item["address"]) == {"city", "country"}
+
+
+def test_from_typed_dict_name_resolution():
+    # A key matching a provider method must yield semantically correct data,
+    # not a type-based fallback value.
+    field = Field(Locale.EN, seed=0xFF)
+    email = Schema.from_typed_dict(User, field=field, iterations=1).create()[0]["email"]
+    assert "@" in email
+
+
+def test_from_typed_dict_is_deterministic():
+    first = Schema.from_typed_dict(User, iterations=3, seed=42).create()
+    second = Schema.from_typed_dict(User, iterations=3, seed=42).create()
+    assert first == second
+
+
+def test_from_typed_dict_iterations():
+    assert len(Schema.from_typed_dict(User, iterations=7).create()) == 7
+
+
+def test_from_typed_dict_with_custom_field_handler():
+    class Record(TypedDict):
+        external_id: str
+        email: str
+
+    field = Field(seed=1)
+    field.register_handler(
+        "external_id", lambda random, **kwargs: random.randint(1, 100)
+    )
+    data = Schema.from_typed_dict(Record, field=field, iterations=3).create()
+
+    for item in data:
+        assert 1 <= item["external_id"] <= 100
+        assert "@" in item["email"]
+
+
+def test_from_typed_dict_respects_field_locale():
+    field = Field(Locale.RU, seed=0xFF)
+    schema = Schema.from_typed_dict(Address, field=field, iterations=1)
+    assert schema.create()[0]["country"]
+
+
+@pytest.mark.parametrize("not_a_typed_dict", [dict, {"a": int}, int, "User"])
+def test_from_typed_dict_raises_type_error(not_a_typed_dict):
+    with pytest.raises(TypeError):
+        Schema.from_typed_dict(not_a_typed_dict)
+
+
+def test_from_typed_dict_raises_field_error_for_unresolvable_key():
+    class Unresolvable(TypedDict):
+        some_unknown_thing: complex
+
+    # Unresolvable keys are reported eagerly, when the schema is built.
+    with pytest.raises(FieldError):
+        Schema.from_typed_dict(Unresolvable, iterations=1)
+
+
+def test_from_typed_dict_inherited_keys():
+    class Base(TypedDict):
+        email: str
+
+    class Derived(Base):
+        username: str
+
+    item = Schema.from_typed_dict(Derived, iterations=1).create()[0]
+    assert set(item) == {"email", "username"}
+
+
+def test_can_resolve(default_field):
+    assert default_field.can_resolve("email") is True
+    assert default_field.can_resolve("person.name") is True
+    assert default_field.can_resolve("definitely_not_a_field") is False
+
+
+def test_can_resolve_custom_handler():
+    field = Field()
+    assert field.can_resolve("my_custom") is False
+    field.register_handler("my_custom", lambda random, **kwargs: 1)
+    assert field.can_resolve("my_custom") is True


### PR DESCRIPTION
Closes #1579.

When records are already described with a `typing.TypedDict`, it would be nice to build a schema from it instead of restating every field by hand. This adds `Schema.from_typed_dict()`.

### Behaviour

Every key of the `TypedDict` becomes a key of each generated record. Values are produced by resolving the key against the data providers — the same lookup `Field` already uses — so a key named `email` yields a real email address rather than a random string:

```python
from typing import TypedDict
from mimesis import Schema

class User(TypedDict):
    name: str
    email: str
    age: int

Schema.from_typed_dict(User, iterations=2).create()
# [{"name": "Cordell", "email": "exposure1874@example.org", "age": 42}, ...]
```

Leaning on the name-based lookup (rather than a purely type-driven mapping like `polyfactory`) keeps the data semantically meaningful, which is the whole point of Mimesis. When a key does not match any provider method, the annotated type is used as a fallback (`int` → `integer_number`, `float` → `float_number`, `bool` → `boolean`, `str` → `word`).

Nested `TypedDict` annotations are expanded recursively (this was the part flagged as tricky in the issue), and the `Annotated`, `Required`, `NotRequired` and `Optional` wrappers are unwrapped before resolution:

```python
class Address(TypedDict):
    city: str
    country: str

class Profile(TypedDict):
    username: str
    age: int
    nickname: NotRequired[str]
    address: Address
```

For custom generation, pass your own `Field` with a registered handler; a key that resolves neither by name nor by type raises `FieldError` eagerly, when the schema is built.

### Also included

`Field.can_resolve(name)` — a small public predicate reporting whether a field name resolves to a value (via a registered handler or a provider method). `from_typed_dict` uses it to choose name- vs type-based generation, and it is handy on its own when building schemas dynamically.

### Notes

- Purely additive; no existing behaviour changes.
- `master` currently has pre-existing failures in `test_field_reseed[*-seed3]` unrelated to this change; everything else in `tests/test_schema.py` passes.

### Tests

New tests in `tests/test_schema.py` cover name resolution, type fallback, `bool`-vs-`int` handling, nested/inherited `TypedDict`s, the wrapper unwrapping, determinism, custom handlers, locale propagation, and the error paths, plus `can_resolve`. `ruff check`, `ruff format --check` and `mypy` are clean on the changed files.